### PR TITLE
Changes needed to (partially) build on Fedora 32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ if(UNIX AND NOT APPLE)
     add_subdirectory(src/helper)
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
 string(TOLOWER ${CMAKE_BUILD_TYPE} PINGNOO_BUILD_TYPE)
 
 if(APPLE)

--- a/deploy.py
+++ b/deploy.py
@@ -115,7 +115,7 @@ def which(appname):
 
     whichstatusresult, output = execute(f'{command} {appname}')
 
-    if whichstatusresult and output:
+    if whichstatusresult == 0 and output:
         return output.split()[0]
 
 
@@ -268,7 +268,7 @@ if platform.system() == "Darwin":
     parser.add_argument('--appleid', type=str, nargs='?', help='apple id to use for notarization')
     parser.add_argument('--password', type=str, nargs='?', help='password for apple id')
 
-parser.add_argument('--version', type=str, nargs='?', help='version string')
+parser.add_argument('--version', type=str, nargs='?', help='version string', required=True)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
The `CMakeLists` changes were needed or else it told me something like "string no output variable specified"

The `deploy` changes:

- needed to find `curl` (every other call seemed to check if the return was 0, as is POSIX compliant)
- if version not given, attempted to parse a `None`

(Side note - IMHO `deploy.py` should be totally refactored using a custom exception type to remove 3/4 of the error checking; refer to the EAFP paradigm of python.)