### PR TITLE
Fix Fedora 32 Build for real this time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ if(UNIX AND NOT APPLE)
     add_subdirectory(src/helper)
 endif()
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
 string(TOLOWER ${CMAKE_BUILD_TYPE} PINGNOO_BUILD_TYPE)
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Pingnoo)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/pingnoo.cmake)
 
 option(Pingnoo_Build_Tests "Build tests" OFF)
@@ -42,10 +46,6 @@ if(UNIX AND NOT APPLE)
     set(NEDRYSOFT_LIBRARY_DIR ${PINGNOO_BINARY_ROOT})
 
     add_subdirectory(src/helper)
-endif()
-
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
 endif()
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} PINGNOO_BUILD_TYPE)

--- a/deploy.py
+++ b/deploy.py
@@ -115,7 +115,7 @@ def which(appname):
 
     whichstatusresult, output = execute(f'{command} {appname}')
 
-    if whichstatusresult and output:
+    if whichstatusresult == 0 and output:
         return output.split()[0]
 
 
@@ -268,7 +268,7 @@ if platform.system() == "Darwin":
     parser.add_argument('--appleid', type=str, nargs='?', help='apple id to use for notarization')
     parser.add_argument('--password', type=str, nargs='?', help='password for apple id')
 
-parser.add_argument('--version', type=str, nargs='?', help='version string')
+parser.add_argument('--version', type=str, nargs='?', help='version string', required=True)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
I noted in #7 it was partial. Turns out the `CMAKE_BUILD_TYPE` needed to be earlier.

Without this, it would put some files in `bin/x86-64/` and others in `bin/x86-64/Release`. May want to open another ticket handling what the actual problem was, since hanging isn't the right answer. ;)
