### PR TITLE
fix: arch deployment

### DIFF
--- a/docker/arch-builder/Dockerfile
+++ b/docker/arch-builder/Dockerfile
@@ -50,20 +50,20 @@ ARG DOCKER_GROUP=teamcity
 ARG DOCKER_USER_ID=0
 ARG DOCKER_GROUP_ID=0
 
-RUN groupadd -g $DOCKER_GROUP_ID $DOCKER_GROUP && useradd -u $DOCKER_USER_ID -m -g $DOCKER_USER $DOCKER_GROUP
+#RUN groupadd -g $DOCKER_GROUP_ID $DOCKER_GROUP && useradd -u $DOCKER_USER_ID -m -g $DOCKER_USER $DOCKER_GROUP
 
 COPY makepkg.conf /etc/makepkg.conf
 
-RUN mkdir /tmp/packages && \
-    mkdir /tmp/sources && \
-    mkdir /tmp/srcpackages && \
-    mkdir /tmp/makepkglogs \
+#RUN mkdir /tmp/packages && \
+#    mkdir /tmp/sources && \
+#    mkdir /tmp/srcpackages && \
+#    mkdir /tmp/makepkglogs
 
-RUN chmod 666 /tmp/packages && \
-    chmod 666 /tmp/sources && \
-    chmod 666 /tmp/srcpackages && \
-    chmod 666 /tmp/makepkglogs \
+#RUN chmod 666 /tmp/packages && \
+#    chmod 666 /tmp/sources && \
+#    chmod 666 /tmp/srcpackages && \
+#    chmod 666 /tmp/makepkglogs
 
-USER $DOCKER_USER
+#USER $DOCKER_USER
 
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -128,9 +128,6 @@ def pkg_create(build_arch, build_type, version, key):
     if key:
         key_param = f'--sign --key {key}'
 
-
-    rm_path('artifacts_')
-
     # create the pkg file
     with msg_printer("Building package"):
         execute(
@@ -143,7 +140,7 @@ def pkg_create(build_arch, build_type, version, key):
             f'mkdir {deployment_dir}/sources && '
             f'mkdir {deployment_dir}/srcpackages && '
             f'mkdir {deployment_dir}/makepkglogs && '
-            f'PKGDEST=artifacts_ makepkg {key_param}'
+            f'PKGDEST=/tmp/artifacts makepkg {key_param}'
              '"', "Failed to build!")
 
     with msg_printer("Creating AUR deployment"):
@@ -162,7 +159,7 @@ def pkg_create(build_arch, build_type, version, key):
     with msg_printer("Moving build artifacts"):
         rm_path('artifacts')
 
-        shutil.copytree(f'{deployment_dir}', 'artifacts/p2')
+        shutil.copytree('/tmp/artifacts', 'artifacts/p2')
         #shutil.copytree(f'{deployment_dir}/makepkg/packages', 'artifacts/packages')
         shutil.copytree(f'{deployment_dir}/aur', 'artifacts/aur')
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,7 +135,7 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'bash -c "cd bin/{build_arch}/Deploy && ls -l -h && sudo -u nobody (mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && makepkg {key_param})"', "Failed to build!")
+            f'sudo -u nobody bash -c "cd bin/{build_arch}/Deploy && ls -lh && mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && makepkg {key_param}"', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -157,7 +157,7 @@ def pkg_create(build_arch, build_type, version, key):
             pkgbuild_file.write(aur_pkgbuild_file_content)
 
         execute('sudo -u nobody bash -c "'
-               f'ls -lhR {deployment_dir}'
+               f'ls -lhR {deployment_dir} && '
                f'cd {deployment_dir}/aur && '
                'makepkg --printsrcinfo > .SRCINFO'
                '"', "Failed to create .SRCINFO!")

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -121,11 +121,7 @@ def pkg_create(build_arch, build_type, version, key):
         with open(f'bin/{build_arch}/Deploy/PKGBUILD', 'w') as pkgbuild_file:
             pkgbuild_file.write(pkgbuild_file_content)
 
-    # remove any previous deployment artifacts
-    os.makedirs('/tmp/deployment')
-
     deployment_dir = '/tmp/deployment'
-    os.makedirs('deployment')
 
     key_param = ""
 
@@ -147,10 +143,6 @@ def pkg_create(build_arch, build_type, version, key):
             f'makepkg {key_param}'
              '"', "Failed to build!")
 
-        shutil.copy2(f'{deployment_dir}/packages', f'deployment/')
-
-    # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
-
     with msg_printer("Creating AUR deployment"):
         shutil.copy2(source_location, f'{deployment_dir}/aur/pingnoo-{git_year}.{git_month}.{git_day}.tar.gz')
         shutil.copy2('pkg/pingnoo.install', f'{deployment_dir}/aur/')
@@ -158,17 +150,20 @@ def pkg_create(build_arch, build_type, version, key):
         with open(f'{deployment_dir}/aur/PKGBUILD', 'w') as pkgbuild_file:
             pkgbuild_file.write(aur_pkgbuild_file_content)
 
-        execute(f'ls -lhR {deployment_dir}', 'failed to look')
-
         execute('sudo -u nobody bash -c "'
                f'ls -lhR {deployment_dir} && '
                f'cd {deployment_dir}/aur && '
                'makepkg --printsrcinfo > .SRCINFO'
                '"', "Failed to create .SRCINFO!")
 
-        shutil.copy2(f'{deployment_dir}/aur', f'deployment/')
+    rm_path('artifacts/packages')
+    rm_path('artifacts/aur')
 
+    os.makedirs('artifacts/packages')
+    os.makedirs('artifacts/aur')
 
+    shutil.copy2(f'{deployment_dir}/packages', 'artifacts/packages')
+    shutil.copy2(f'{deployment_dir}/aur', 'artifacts/aur')
 
 def main():
     parser = argparse.ArgumentParser(description='pkg build script')

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,7 +135,7 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'bash -c "cd bin/{build_arch}/Deploy && ls -l -h && sudo -u nobody makepkg {key_param}"', "Failed to build!")
+            f'bash -c "cd bin/{build_arch}/Deploy && ls -l -h && sudo -u nobody (mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && makepkg {key_param})"', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,8 +135,8 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'sudo -u nobody bash -c "'
-             'cd bin/{build_arch}/Deploy && '
+             'sudo -u nobody bash -c "'
+            f'cd bin/{build_arch}/Deploy && '
              'mkdir /tmp/packages && '
              'mkdir /tmp/sources && '
              'mkdir /tmp/srcpackages && '

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,12 +135,12 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'sudo -u nobody && "cd bin/{build_arch}/Deploy" && '
-             'sudo -u nobody && "mkdir /tmp/packages" && '
-             'sudo -u nobody && "mkdir /tmp/sources" && '
-             'sudo -u nobody && "mkdir /tmp/srcpackages" && '
-             'sudo -u nobody && "mkdir /tmp/makepkglogs" && '
-             'sudo -u nobody && "makepkg {key_param}"', "Failed to build!")
+            f'sudo -u nobody "cd bin/{build_arch}/Deploy" && '
+             'sudo -u nobody "mkdir /tmp/packages" && '
+             'sudo -u nobody "mkdir /tmp/sources" && '
+             'sudo -u nobody "mkdir /tmp/srcpackages" && '
+             'sudo -u nobody "mkdir /tmp/makepkglogs" && '
+             'sudo -u nobody "makepkg {key_param}"', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -128,9 +128,8 @@ def pkg_create(build_arch, build_type, version, key):
     if key:
         key_param = f'--sign --key {key}'
 
-    with msg_printer("Creating artifacts folder"):
-        rm_path('artifacts_')
-        os.makedirs('artifacts_')
+
+    rm_path('artifacts_')
 
     # create the pkg file
     with msg_printer("Building package"):

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -158,8 +158,8 @@ def pkg_create(build_arch, build_type, version, key):
 
     rm_path('artifacts')
 
-    shutil.copy2(f'{deployment_dir}/packages', 'artifacts/packages')
-    shutil.copy2(f'{deployment_dir}/aur', 'artifacts/aur')
+    shutil.copytree(f'{deployment_dir}/packages', 'artifacts/packages')
+    shutil.copytree(f'{deployment_dir}/aur', 'artifacts/aur')
 
 def main():
     parser = argparse.ArgumentParser(description='pkg build script')

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -139,6 +139,7 @@ def pkg_create(build_arch, build_type, version, key):
              'export GNUPGHOME=/tmp/.gnupg && ' 
             f'cd bin/{build_arch}/Deploy && '
             f'mkdir {deployment_dir} && '
+            f'mkdir {deployment_dir}/aur && '
             f'mkdir {deployment_dir}/packages && '
             f'mkdir {deployment_dir}/sources && '
             f'mkdir {deployment_dir}/srcpackages && '
@@ -149,7 +150,6 @@ def pkg_create(build_arch, build_type, version, key):
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 
     with msg_printer("Creating AUR deployment"):
-        os.makedirs(f'{deployment_dir}/aur')
         shutil.copy2(source_location, f'{deployment_dir}/aur/pingnoo-{git_year}.{git_month}.{git_day}.tar.gz')
         shutil.copy2('pkg/pingnoo.install', f'{deployment_dir}/aur/')
 
@@ -157,6 +157,7 @@ def pkg_create(build_arch, build_type, version, key):
             pkgbuild_file.write(aur_pkgbuild_file_content)
 
         execute('sudo -u nobody bash -c "'
+               f'ls -lhR {deployment_dir}'
                f'cd {deployment_dir}/aur && '
                'makepkg --printsrcinfo > .SRCINFO'
                '"', "Failed to create .SRCINFO!")

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -123,7 +123,7 @@ def pkg_create(build_arch, build_type, version, key):
 
     # remove any previous deployment artifacts
     rm_path('/tmp/deployment')
-    os.makedirs('/tmp/deployment')
+    #os.makedirs('/tmp/deployment')
 
     deployment_dir = '/tmp/deployment'
 
@@ -138,6 +138,7 @@ def pkg_create(build_arch, build_type, version, key):
              'sudo -u nobody bash -c "'
              'export GNUPGHOME=/tmp/.gnupg && ' 
             f'cd bin/{build_arch}/Deploy && '
+            f'mkdir {deployment_dir} && '
             f'mkdir {deployment_dir}/packages && '
             f'mkdir {deployment_dir}/sources && '
             f'mkdir {deployment_dir}/srcpackages && '

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -126,6 +126,7 @@ def pkg_create(build_arch, build_type, version, key):
     #os.makedirs('/tmp/deployment')
 
     deployment_dir = '/tmp/deployment'
+    os.makedirs('deployment')
 
     key_param = ""
 
@@ -149,6 +150,8 @@ def pkg_create(build_arch, build_type, version, key):
              'ls -lHR .'
              '"', "Failed to build!")
 
+        shutil.copy2(f'{deployment_dir}/packages', f'deployment/')
+
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 
     with msg_printer("Creating AUR deployment"):
@@ -165,6 +168,9 @@ def pkg_create(build_arch, build_type, version, key):
                f'cd {deployment_dir}/aur && '
                'makepkg --printsrcinfo > .SRCINFO'
                '"', "Failed to create .SRCINFO!")
+
+        shutil.copy2(f'{deployment_dir}/aur', f'deployment/')
+
 
 
 def main():

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -160,7 +160,7 @@ def pkg_create(build_arch, build_type, version, key):
         rm_path('artifacts')
 
         shutil.copytree(f'{deployment_dir}', 'artifacts/p2')
-        shutil.copytree(f'{deployment_dir}/makepkg/packages', 'artifacts/packages')
+        #shutil.copytree(f'{deployment_dir}/makepkg/packages', 'artifacts/packages')
         shutil.copytree(f'{deployment_dir}/aur', 'artifacts/aur')
 
 def main():

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -122,7 +122,6 @@ def pkg_create(build_arch, build_type, version, key):
             pkgbuild_file.write(pkgbuild_file_content)
 
     # remove any previous deployment artifacts
-    shutil.rmtree('/tmp/deployment')
     os.makedirs('/tmp/deployment')
 
     deployment_dir = '/tmp/deployment'

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -156,11 +156,7 @@ def pkg_create(build_arch, build_type, version, key):
                'makepkg --printsrcinfo > .SRCINFO'
                '"', "Failed to create .SRCINFO!")
 
-    rm_path('artifacts/packages')
-    rm_path('artifacts/aur')
-
-    os.makedirs('artifacts/packages')
-    os.makedirs('artifacts/aur')
+    rm_path('artifacts')
 
     shutil.copy2(f'{deployment_dir}/packages', 'artifacts/packages')
     shutil.copy2(f'{deployment_dir}/aur', 'artifacts/aur')

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -158,6 +158,8 @@ def pkg_create(build_arch, build_type, version, key):
         with open(f'{deployment_dir}/aur/PKGBUILD', 'w') as pkgbuild_file:
             pkgbuild_file.write(aur_pkgbuild_file_content)
 
+        execute(f'ls -lhR {deployment_dir}', 'failed to look')
+
         execute('sudo -u nobody bash -c "'
                f'ls -lhR {deployment_dir} && '
                f'cd {deployment_dir}/aur && '

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -121,7 +121,7 @@ def pkg_create(build_arch, build_type, version, key):
         with open(f'bin/{build_arch}/Deploy/PKGBUILD', 'w') as pkgbuild_file:
             pkgbuild_file.write(pkgbuild_file_content)
 
-    deployment_dir = '/tmp/deployment'
+    build_dir = '/tmp/build'
 
     key_param = ""
 
@@ -134,34 +134,36 @@ def pkg_create(build_arch, build_type, version, key):
              'sudo -u nobody bash -c "'
              'export GNUPGHOME=/tmp/.gnupg && ' 
             f'cd bin/{build_arch}/Deploy && '
-            f'mkdir {deployment_dir} && '
-            f'mkdir {deployment_dir}/aur && '
-            f'mkdir {deployment_dir}/packages && '
-            f'mkdir {deployment_dir}/sources && '
-            f'mkdir {deployment_dir}/srcpackages && '
-            f'mkdir {deployment_dir}/makepkglogs && '
+            f'mkdir {build_dir} && '
+            f'mkdir {build_dir}/aur && '
+            f'mkdir {build_dir}/packages && '
+            f'mkdir {build_dir}/sources && '
+            f'mkdir {build_dir}/srcpackages && '
+            f'mkdir {build_dir}/makepkglogs && '
             f'PKGDEST=/tmp/artifacts makepkg {key_param}'
              '"', "Failed to build!")
 
     with msg_printer("Creating AUR deployment"):
-        shutil.copy2(source_location, f'{deployment_dir}/aur/pingnoo-{git_year}.{git_month}.{git_day}.tar.gz')
-        shutil.copy2('pkg/pingnoo.install', f'{deployment_dir}/aur/')
+        shutil.copy2(source_location, f'{build_dir}/aur/pingnoo-{git_year}.{git_month}.{git_day}.tar.gz')
+        shutil.copy2('pkg/pingnoo.install', f'{build_dir}/aur/')
 
-        with open(f'{deployment_dir}/aur/PKGBUILD', 'w') as pkgbuild_file:
+        with open(f'{build_dir}/aur/PKGBUILD', 'w') as pkgbuild_file:
             pkgbuild_file.write(aur_pkgbuild_file_content)
 
         execute('sudo -u nobody bash -c "'
-               f'ls -lhR {deployment_dir} && '
-               f'cd {deployment_dir}/aur && '
+               f'cd {build_dir}/aur && '
                'makepkg --printsrcinfo > .SRCINFO'
                '"', "Failed to create .SRCINFO!")
+
+    # this is a bit of a mess, the arch linux makepkg tool will not allow you to run it as root, this causes a lot
+    # of isuees with the TeamCity docker in docker agent with permissions.  To solve this, the build is done in
+    # the tmp directory and then the files moved to the artifacts folder for the server to pick up
 
     with msg_printer("Moving build artifacts"):
         rm_path('artifacts')
 
-        shutil.copytree('/tmp/artifacts', 'artifacts/p2')
-        #shutil.copytree(f'{deployment_dir}/makepkg/packages', 'artifacts/packages')
-        shutil.copytree(f'{deployment_dir}/aur', 'artifacts/aur')
+        shutil.copytree('/tmp/artifacts', 'artifacts/package')
+        shutil.copytree(f'{build_dir}/aur', 'artifacts/aur')
 
 def main():
     parser = argparse.ArgumentParser(description='pkg build script')

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,12 +135,14 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'sudo -u nobody "cd bin/{build_arch}/Deploy" && '
-             'sudo -u nobody "mkdir /tmp/packages" && '
-             'sudo -u nobody "mkdir /tmp/sources" && '
-             'sudo -u nobody "mkdir /tmp/srcpackages" && '
-             'sudo -u nobody "mkdir /tmp/makepkglogs" && '
-             'sudo -u nobody "makepkg {key_param}"', "Failed to build!")
+            f'sudo -u nobody bash -c "'
+             'cd bin/{build_arch}/Deploy && '
+             'mkdir /tmp/packages && '
+             'mkdir /tmp/sources && '
+             'mkdir /tmp/srcpackages && '
+             'mkdir /tmp/makepkglogs && '
+            f'makepkg {key_param}'
+             '"', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -160,7 +160,7 @@ def pkg_create(build_arch, build_type, version, key):
         rm_path('artifacts')
 
         shutil.copytree(f'{deployment_dir}', 'artifacts/p2')
-        shutil.copytree(f'{deployment_dir}/packages', 'artifacts/packages')
+        shutil.copytree(f'{deployment_dir}/makepkg/packages', 'artifacts/packages')
         shutil.copytree(f'{deployment_dir}/aur', 'artifacts/aur')
 
 def main():

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,7 +135,12 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'su nobody && cd bin/{build_arch}/Deploy && ls -lh && mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && ls -lh /tmp && makepkg {key_param}', "Failed to build!")
+            f'sudo -u nobody && "cd bin/{build_arch}/Deploy" && '
+             'sudo -u nobody && "mkdir /tmp/packages" && '
+             'sudo -u nobody && "mkdir /tmp/sources" && '
+             'sudo -u nobody && "mkdir /tmp/srcpackages" && '
+             'sudo -u nobody && "mkdir /tmp/makepkglogs" && '
+             'sudo -u nobody && "makepkg {key_param}"', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -122,10 +122,10 @@ def pkg_create(build_arch, build_type, version, key):
             pkgbuild_file.write(pkgbuild_file_content)
 
     # remove any previous deployment artifacts
-    rm_path('deployment')
-    os.makedirs('deployment')
+    rm_path('/tmp/deployment')
+    os.makedirs('/tmp/deployment')
 
-    deployment_dir = os.getcwd()+"/deployment"
+    deployment_dir = '/tmp/deployment'
 
     key_param = ""
 
@@ -136,11 +136,12 @@ def pkg_create(build_arch, build_type, version, key):
     with msg_printer("Building package"):
         execute(
              'sudo -u nobody bash -c "'
+             'export GNUPGHOME=/tmp/.gnupg && ' 
             f'cd bin/{build_arch}/Deploy && '
-             'mkdir /tmp/packages && '
-             'mkdir /tmp/sources && '
-             'mkdir /tmp/srcpackages && '
-             'mkdir /tmp/makepkglogs && '
+            f'mkdir {deployment_dir}/packages && '
+            f'mkdir {deployment_dir}/sources && '
+            f'mkdir {deployment_dir}/srcpackages && '
+            f'mkdir {deployment_dir}/makepkglogs && '
             f'makepkg {key_param}'
              '"', "Failed to build!")
 
@@ -154,7 +155,10 @@ def pkg_create(build_arch, build_type, version, key):
         with open(f'{deployment_dir}/aur/PKGBUILD', 'w') as pkgbuild_file:
             pkgbuild_file.write(aur_pkgbuild_file_content)
 
-        execute(f'cd {deployment_dir}/aur && makepkg --printsrcinfo > .SRCINFO', "Failed to create .SRCINFO!")
+        execute('sudo -u nobody bash -c "'
+               f'cd {deployment_dir}/aur && '
+               'makepkg --printsrcinfo > .SRCINFO'
+               '"', "Failed to create .SRCINFO!")
 
 
 def main():

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -144,7 +144,9 @@ def pkg_create(build_arch, build_type, version, key):
             f'mkdir {deployment_dir}/sources && '
             f'mkdir {deployment_dir}/srcpackages && '
             f'mkdir {deployment_dir}/makepkglogs && '
-            f'makepkg {key_param}'
+            f'makepkg {key_param} && '
+             'pwd && '
+             'ls -lHR .'
              '"', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,7 +135,7 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'sudo -u nobody bash -c "cd bin/{build_arch}/Deploy && ls -lh && mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && makepkg {key_param}"', "Failed to build!")
+            f'sudo -u nobody bash -c "cd bin/{build_arch}/Deploy && ls -lh && mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && ls -lh /tmp && makepkg {key_param}"', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -156,10 +156,12 @@ def pkg_create(build_arch, build_type, version, key):
                'makepkg --printsrcinfo > .SRCINFO'
                '"', "Failed to create .SRCINFO!")
 
-    rm_path('artifacts')
+    with msg_printer("Moving build artifacts"):
+        rm_path('artifacts')
 
-    shutil.copytree(f'{deployment_dir}/packages', 'artifacts/packages')
-    shutil.copytree(f'{deployment_dir}/aur', 'artifacts/aur')
+        shutil.copytree(f'{deployment_dir}', 'artifacts/p2')
+        shutil.copytree(f'{deployment_dir}/packages', 'artifacts/packages')
+        shutil.copytree(f'{deployment_dir}/aur', 'artifacts/aur')
 
 def main():
     parser = argparse.ArgumentParser(description='pkg build script')

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -128,6 +128,10 @@ def pkg_create(build_arch, build_type, version, key):
     if key:
         key_param = f'--sign --key {key}'
 
+    with msg_printer("Creating artifacts folder"):
+        rm_path('artifacts_')
+        os.makedirs('artifacts_')
+
     # create the pkg file
     with msg_printer("Building package"):
         execute(
@@ -140,7 +144,7 @@ def pkg_create(build_arch, build_type, version, key):
             f'mkdir {deployment_dir}/sources && '
             f'mkdir {deployment_dir}/srcpackages && '
             f'mkdir {deployment_dir}/makepkglogs && '
-            f'makepkg {key_param}'
+            f'PKGDEST=artifacts_ makepkg {key_param}'
              '"', "Failed to build!")
 
     with msg_printer("Creating AUR deployment"):

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,7 +135,7 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'sudo -u nobody bash -c "cd bin/{build_arch}/Deploy && ls -lh && mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && ls -lh /tmp && makepkg {key_param}"', "Failed to build!")
+            f'su nobody && cd bin/{build_arch}/Deploy && ls -lh && mkdir /tmp/packages && /tmp/sources && mkdir /tmp/srcpackages && mkdir /tmp/makepkglogs && ls -lh /tmp && makepkg {key_param}', "Failed to build!")
 
     # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -135,7 +135,9 @@ def pkg_create(build_arch, build_type, version, key):
     # create the pkg file
     with msg_printer("Building package"):
         execute(
-            f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"', "Failed to build!")
+            f'bash -c "cd bin/{build_arch}/Deploy && ls -l -h && sudo -u nobody makepkg {key_param}"', "Failed to build!")
+
+    # f'PKGDEST={deployment_dir} bash -c "cd bin/{build_arch}/Deploy && PKGDEST={deployment_dir} && BUILDDIR=/tmp/makepkg && sudo -u nobody makepkg {key_param}"'
 
     with msg_printer("Creating AUR deployment"):
         os.makedirs(f'{deployment_dir}/aur')

--- a/pingnoo_support_python/makepkg.py
+++ b/pingnoo_support_python/makepkg.py
@@ -122,8 +122,8 @@ def pkg_create(build_arch, build_type, version, key):
             pkgbuild_file.write(pkgbuild_file_content)
 
     # remove any previous deployment artifacts
-    rm_path('/tmp/deployment')
-    #os.makedirs('/tmp/deployment')
+    shutil.rmtree('/tmp/deployment')
+    os.makedirs('/tmp/deployment')
 
     deployment_dir = '/tmp/deployment'
     os.makedirs('deployment')
@@ -145,9 +145,7 @@ def pkg_create(build_arch, build_type, version, key):
             f'mkdir {deployment_dir}/sources && '
             f'mkdir {deployment_dir}/srcpackages && '
             f'mkdir {deployment_dir}/makepkglogs && '
-            f'makepkg {key_param} && '
-             'pwd && '
-             'ls -lHR .'
+            f'makepkg {key_param}'
              '"', "Failed to build!")
 
         shutil.copy2(f'{deployment_dir}/packages', f'deployment/')

--- a/pkg/PKGBUILD.in
+++ b/pkg/PKGBUILD.in
@@ -27,7 +27,7 @@ prepare=()
 
 build() {
     cmake -B build -S $${pkgname} -DCMAKE_SKIP_RPATH=True -DPINGNOO_GIT_YEAR=$GIT_YEAR -DPINGNOO_GIT_MONTH=$GIT_MONTH -DPINGNOO_GIT_DAY=$GIT_DAY -DPINGNOO_GIT_HASH=$GIT_HASH -DPINGNOO_GIT_BRANCH=$GIT_BRANCH -DPINGNOO_GIT_UNCOMMITTED=$GIT_UNCOMMITTED
-    make -C build
+    make -j`nproc` -C build
 }
 
 package() {


### PR DESCRIPTION
- arch deployment was a real pain to get working, the makepkg tool cannot be run as root, with TeamCity using docker in docker, this lead to a whole load of permissions problems and a lot of trial and error on getting the build and eventually the artefacts to work.