### PR TITLE
fix: resolved std::chrono & std::thread issues

### DIFF
--- a/src/components/Core/CoreComponent.cpp
+++ b/src/components/Core/CoreComponent.cpp
@@ -92,6 +92,10 @@ auto CoreComponent::finaliseEvent() -> void {
         delete m_hostMaskerSettingsPage;
     }
 
+    if (m_systemTrayIconManager) {
+        delete  m_systemTrayIconManager;
+    }
+
     if (m_themeSettingsPage) {
         delete m_themeSettingsPage;
     }

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.cpp
@@ -194,7 +194,7 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine::singleShot(
     int returnValue;
     sockaddr_in6 sourceAddress, targetAddress;
 
-    auto epoch = std::chrono::system_clock::now();
+    auto epoch = QDateTime::currentDateTime();
 
 #if defined(_WIN64)
     IP_OPTION_INFORMATION32 options;
@@ -294,7 +294,7 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine::singleShot(
            resultCode,
            replyHost,
            epoch,
-           std::chrono::duration<double, std::milli>(roundTripTime),
+           roundTripTime/1000.0,
            nullptr);
 }
 

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.cpp
@@ -225,28 +225,28 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine::singleShot(
 
     if (hostAddress.protocol() == QAbstractSocket::IPv4Protocol) {
         returnValue = IcmpSendEcho(
-                icmpHandle,
-                hostAddress.toIPv4Address(),
-                dataBuffer.data(),
-                static_cast<WORD>(dataBuffer.length()), pipOptions,
-                replyBuffer.data(),
-                static_cast<DWORD>(replyBuffer.length()),
-                std::chrono::duration<DWORD, std::milli>(
-                        DefaultTransmitTimeout).count() ); // NOLINT(cppcoreguidelines-pro-type-union-access)
+            icmpHandle,
+            hostAddress.toIPv4Address(),
+            dataBuffer.data(),
+            static_cast<WORD>(dataBuffer.length()), pipOptions,
+            replyBuffer.data(),
+            static_cast<DWORD>(replyBuffer.length()),
+            DefaultTransmitTimeout
+        ); // NOLINT(cppcoreguidelines-pro-type-union-access)
     } else {
         returnValue = Icmp6SendEcho2(
-                icmpHandle,
-                nullptr,
-                nullptr,
-                nullptr,
-                &sourceAddress,
-                &targetAddress,
-                dataBuffer.data(),
-                static_cast<WORD>(dataBuffer.length()),
-                pipOptions,
-                replyBuffer.data(), static_cast<DWORD>(replyBuffer.length()),
-                std::chrono::duration<DWORD, std::milli>(
-                        DefaultTransmitTimeout).count() );  // NOLINT(cppcoreguidelines-pro-type-union-access)
+            icmpHandle,
+            nullptr,
+            nullptr,
+            nullptr,
+            &sourceAddress,
+            &targetAddress,
+            dataBuffer.data(),
+            static_cast<WORD>(dataBuffer.length()),
+            pipOptions,
+            replyBuffer.data(), static_cast<DWORD>(replyBuffer.length()),
+            DefaultTransmitTimeout
+        );  // NOLINT(cppcoreguidelines-pro-type-union-access)
     }
 
     auto roundTripTime = timer.nsecsElapsed();
@@ -290,7 +290,7 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine::singleShot(
            resultCode,
            replyHost,
            epoch,
-           roundTripTime/1e9,
+           roundTripTime/NanosecondsInMillisecond,
            nullptr);
 }
 

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.cpp
@@ -33,6 +33,7 @@
 #include <WinSock2.h>
 #include <iphlpapi.h>
 #include <IcmpAPI.h>
+#include <iostream>
 
 constexpr auto DefaultTransmitTimeout = 1000;
 constexpr auto DefaultReplyTimeout = 3000;
@@ -233,7 +234,7 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine::singleShot(
             replyBuffer.data(),
             static_cast<DWORD>(replyBuffer.length()),
             timeout*1000
-        ); // NOLINT(cppcoreguidelines-pro-type-union-access)
+        ); // NOLINT(cppcoreguidelines-pro-type-union-access)*/
     } else {
         returnValue = Icmp6SendEcho2(
             icmpHandle,
@@ -288,7 +289,7 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine::singleShot(
         }
     }
 
-    IcmpCloseHandle(icmpHandle);
+    //IcmpCloseHandle(icmpHandle);
 
     return Nedrysoft::RouteAnalyser::PingResult(
         0,

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.h
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingEngine.h
@@ -59,31 +59,31 @@ namespace Nedrysoft { namespace ICMPAPIPingEngine {
             *
             * @see         Nedrysoft::RouteAnalyser::IPingEngine::setInterval
             *
-            * @param[in]   interval interval time.
+            * @param[in]   interval the time between successive pings in milliseconds.
             *
             * @returns     returns true on success; otherwise false.
             */
-            auto setInterval(std::chrono::milliseconds interval) -> bool override;
+            auto setInterval(int interval) -> bool override;
 
             /**
              * @brief       Returns the interval set on the engine.
              *
              * @see         Nedrysoft::RouteAnalyser::IPingEngine::interval
              *
-             * @returns     the interval.
+             * @returns     the interval between successive pings in milliseconds.
              */
-            auto interval() -> std::chrono::milliseconds override;
+            auto interval() -> int override;
 
             /**
              * @brief       Sets the reply timeout for this engine instance.
              *
              * @see         Nedrysoft::RouteAnalyser::IPingEngine::setTimeout
              *
-             * @param[in]   timeout the amount of time before we consider that the packet was lost.
+             * @param[in]   timeout the number of milliseconds to wait for a reply.
              *
              * @returns     true on success; otherwise false.
              */
-            auto setTimeout(std::chrono::milliseconds timeout) -> bool override;
+            auto setTimeout(int timeout) -> bool override;
 
             /**
              * @brief       Starts ping operations for this engine instance.
@@ -160,7 +160,7 @@ namespace Nedrysoft { namespace ICMPAPIPingEngine {
              *
              * @returns     the time epoch.
              */
-            auto epoch() -> std::chrono::system_clock::time_point override;
+            auto epoch() -> QDateTime override;
 
             /**
              * @brief       Returns the list of ping targets for the engine.

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
@@ -55,7 +55,10 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
 
     m_isRunning = true;
 
+    qDebug() << "ICMPAPIPingTransmitter started" << ((uint64_t) this);
+
     while (m_isRunning) {
+        //qDebug() << "m_isRunning" << m_isRunning << ((uint64_t) &m_isRunning);
         timer.restart();
 
         m_targetsMutex.lock();
@@ -91,6 +94,8 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
 
         sampleNumber++;
     }
+
+    qDebug() << "ICMPAPIPingTransmitter exiting" << ((uint64_t) this);
 }
 
 auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::setInterval(int interval) -> bool {

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
@@ -43,6 +43,11 @@ Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::ICMPAPIPingTransmitter(
 
 }
 
+Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::~ICMPAPIPingTransmitter() {
+    qDeleteAll(m_targets);
+}
+
+
 void Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::addTarget(
         Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTarget *target) {
 
@@ -55,10 +60,7 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
 
     m_isRunning = true;
 
-    qDebug() << "ICMPAPIPingTransmitter started" << ((uint64_t) this);
-
     while (m_isRunning) {
-        //qDebug() << "m_isRunning" << m_isRunning << ((uint64_t) &m_isRunning);
         timer.restart();
 
         m_targetsMutex.lock();
@@ -70,9 +72,11 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
 
             pingWorker->moveToThread(pingThread);
 
-            connect(pingThread, &QThread::started, pingWorker, &ICMPAPIPingWorker::doWork);
             connect(pingThread, &QThread::finished, pingThread, &QThread::deleteLater);
-            connect(pingThread, &QThread::finished, pingWorker, &ICMPAPIPingWorker::deleteLater);
+
+            connect(pingThread, &QThread::started, pingWorker, &ICMPAPIPingWorker::doWork);
+            //connect(pingThread, &QThread::finished, pingThread, &QThread::deleteLater);
+            //connect(pingThread, &QThread::finished, pingWorker, &ICMPAPIPingWorker::deleteLater);
 
             connect(pingWorker,
                 &ICMPAPIPingWorker::result,
@@ -94,8 +98,6 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
 
         sampleNumber++;
     }
-
-    qDebug() << "ICMPAPIPingTransmitter exiting" << ((uint64_t) this);
 }
 
 auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::setInterval(int interval) -> bool {

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
@@ -28,14 +28,11 @@
 #include "ICMPAPIPingWorker.h"
 
 #include <QThread>
-#include <chrono>
 #include <cstdint>
 
-using namespace std::chrono_literals;
-
-constexpr auto DefaultTransmitInterval = 1s;
-constexpr auto DefaultReplyTimeout = 3s;
-constexpr auto DefaultTransmitTimeout = 3s;
+constexpr auto DefaultTransmitInterval = 1000;
+constexpr auto DefaultReplyTimeout = 3000;
+constexpr auto DefaultTransmitTimeout = 3000;
 
 Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::ICMPAPIPingTransmitter(
         Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine *engine) :
@@ -53,13 +50,13 @@ void Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::addTarget(
 }
 
 auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
-    std::chrono::high_resolution_clock::time_point startTime;
     unsigned long sampleNumber = 0;
+    QElapsedTimer timer;
 
     m_isRunning = true;
 
     while (m_isRunning) {
-        startTime = std::chrono::high_resolution_clock::now();
+        timer.restart();
 
         m_targetsMutex.lock();
 
@@ -75,27 +72,28 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
             connect(pingThread, &QThread::finished, pingWorker, &ICMPAPIPingWorker::deleteLater);
 
             connect(pingWorker,
-                    &ICMPAPIPingWorker::result,
-                    this,
-                    &ICMPAPIPingTransmitter::result,
-                    Qt::DirectConnection);
+                &ICMPAPIPingWorker::result,
+                this,
+                &ICMPAPIPingTransmitter::result,
+                Qt::DirectConnection
+            );
 
             pingThread->start();
         }
 
         m_targetsMutex.unlock();
 
-        auto diff = std::chrono::high_resolution_clock::now() - startTime;
+        auto duration = timer.elapsed();
 
-        if (diff < m_interval) {
-            std::this_thread::sleep_for(m_interval - diff);
+        if (duration < m_interval) {
+            QThread::msleep(m_interval - duration);
         }
 
         sampleNumber++;
     }
 }
 
-auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::setInterval(std::chrono::milliseconds interval) -> bool {
+auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::setInterval(int interval) -> bool {
     m_interval = interval;
 
     return true;

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.cpp
@@ -70,13 +70,15 @@ auto Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTransmitter::doWork() -> void {
 
             auto pingThread = new QThread();
 
+            connect(pingThread, &QThread::started, pingWorker, &ICMPAPIPingWorker::doWork);
+
             pingWorker->moveToThread(pingThread);
 
-            connect(pingThread, &QThread::finished, pingThread, &QThread::deleteLater);
+            connect(pingWorker, &ICMPAPIPingWorker::destroyed, [=]() {
+                pingThread->quit();
+            });
 
-            connect(pingThread, &QThread::started, pingWorker, &ICMPAPIPingWorker::doWork);
-            //connect(pingThread, &QThread::finished, pingThread, &QThread::deleteLater);
-            //connect(pingThread, &QThread::finished, pingWorker, &ICMPAPIPingWorker::deleteLater);
+            connect(pingThread, &QThread::finished, pingThread, &QThread::deleteLater, Qt::DirectConnection);
 
             connect(pingWorker,
                 &ICMPAPIPingWorker::result,

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.h
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.h
@@ -55,6 +55,11 @@ namespace Nedrysoft { namespace ICMPAPIPingEngine {
             explicit ICMPAPIPingTransmitter(Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine *engine);
 
             /**
+             * "brief       Destroys the ICMPAPIPingTransmitter.
+             */
+            ~ICMPAPIPingTransmitter();
+
+            /**
              * @brief       Sets the interval between a set of pings.
              *
              * @param[in]   interval the interval between pings in milliseconds.

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.h
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingTransmitter.h
@@ -57,9 +57,9 @@ namespace Nedrysoft { namespace ICMPAPIPingEngine {
             /**
              * @brief       Sets the interval between a set of pings.
              *
-             * @param[in]   interval the interval.
+             * @param[in]   interval the interval between pings in milliseconds.
              */
-            auto setInterval(std::chrono::milliseconds interval) -> bool;
+            auto setInterval(int interval) -> bool;
 
             /**
              * @brief       The transmitter thread worker.
@@ -85,7 +85,7 @@ namespace Nedrysoft { namespace ICMPAPIPingEngine {
         private:
             //! @cond
 
-            std::chrono::milliseconds m_interval = {};
+            int m_interval;
             Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine *m_engine;
 
             QList<Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingTarget *> m_targets;

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingWorker.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingWorker.cpp
@@ -54,6 +54,8 @@ void Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingWorker::doWork() {
     pingResult.setTarget(m_target);
 
     Q_EMIT result(pingResult);
+
+    deleteLater();
 }
 
 

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingWorker.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingWorker.cpp
@@ -28,12 +28,9 @@
 #include "ICMPAPIPingTarget.h"
 
 #include <QThread>
-#include <chrono>
 #include <windows.h>
 
-using namespace std::chrono_literals;
-
-constexpr auto DefaultTransmitTimeout = 3s;
+constexpr auto DefaultTransmitTimeout = 3000;
 
 Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingWorker::ICMPAPIPingWorker(
         Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingEngine *engine,
@@ -48,9 +45,10 @@ Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingWorker::ICMPAPIPingWorker(
 
 void Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingWorker::doWork() {
     Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingResult pingResult = m_engine->singleShot(
-            m_target->hostAddress(),
-            m_target->ttl(),
-            std::chrono::duration<DWORD, std::milli>(DefaultTransmitTimeout).count());
+        m_target->hostAddress(),
+        m_target->ttl(),
+        DefaultTransmitTimeout)
+    );
 
     pingResult.setSampleNumber(m_sampleNumber);
     pingResult.setTarget(m_target);

--- a/src/components/ICMPAPIPingEngine/ICMPAPIPingWorker.cpp
+++ b/src/components/ICMPAPIPingEngine/ICMPAPIPingWorker.cpp
@@ -47,7 +47,7 @@ void Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingWorker::doWork() {
     Nedrysoft::ICMPAPIPingEngine::ICMPAPIPingResult pingResult = m_engine->singleShot(
         m_target->hostAddress(),
         m_target->ttl(),
-        DefaultTransmitTimeout)
+        DefaultTransmitTimeout
     );
 
     pingResult.setSampleNumber(m_sampleNumber);

--- a/src/components/ICMPPingEngine/ICMPPingEngine.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingEngine.cpp
@@ -162,7 +162,8 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::start() -> bool {
     connect(d->m_receiverWorker,
             &Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::packetReceived,
             this,
-            &Nedrysoft::ICMPPingEngine::ICMPPingEngine::onPacketReceived
+            &Nedrysoft::ICMPPingEngine::ICMPPingEngine::onPacketReceived,
+            Qt::DirectConnection
     );
 
     // transmitter thread

--- a/src/components/ICMPPingEngine/ICMPPingEngine.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingEngine.cpp
@@ -36,14 +36,11 @@
 #include <QMap>
 #include <QMutex>
 #include <QThread>
-#include <chrono>
 #include <cstdint>
 
-using namespace std::chrono_literals;
-
-constexpr auto DefaultReceiveTimeout = 1s;
-constexpr auto DefaultTerminateThreadTimeout = 5s;
-constexpr auto DefaultTransmitInterval = 2.5s;
+constexpr auto DefaultReceiveTimeout = 1000;
+constexpr auto DefaultTerminateThreadTimeout = 5000;
+constexpr auto DefaultTransmitInterval = 2500;
 
 constexpr auto SecondsToMs(double seconds) {
     return seconds*1000;
@@ -66,8 +63,9 @@ class Nedrysoft::ICMPPingEngine::ICMPPingEngineData {
                 m_transmitterThread(nullptr),
                 m_timeoutThread(nullptr),
                 m_timeout(DefaultReceiveTimeout),
-                m_epoch(std::chrono::system_clock::now()),
-                m_receiverWorker(nullptr) {
+                m_epoch(QDateTime::currentDateTime()),
+                m_receiverWorker(nullptr),
+                m_interval(DefaultTransmitInterval) {
 
         }
 
@@ -88,11 +86,11 @@ class Nedrysoft::ICMPPingEngine::ICMPPingEngineData {
 
         QList<Nedrysoft::ICMPPingEngine::ICMPPingTarget *> m_targetList;
 
-        std::chrono::milliseconds m_timeout = {};
+        int m_timeout;
 
-        std::chrono::milliseconds m_interval = 2500ms;
+        int m_interval;
 
-        std::chrono::system_clock::time_point m_epoch;
+        QDateTime m_epoch;
 
         Nedrysoft::Core::IPVersion m_version;
 
@@ -190,8 +188,6 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::start() -> bool {
 }
 
 auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::doStop() -> bool {
-    auto waitTime = std::chrono::duration_cast<std::chrono::milliseconds>(DefaultTerminateThreadTimeout);
-
     if (d->m_transmitterWorker) {
         d->m_transmitterWorker->m_isRunning = false;
     }
@@ -209,7 +205,7 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::doStop() -> bool {
     }
 
     if (d->m_transmitterThread) {
-        d->m_transmitterThread->wait(waitTime.count());
+        d->m_transmitterThread->wait(DefaultTerminateThreadTimeout);
 
         if (d->m_transmitterThread->isRunning()) {
             d->m_transmitterThread->terminate();
@@ -221,7 +217,7 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::doStop() -> bool {
     }
 
     if (d->m_timeoutThread) {
-        d->m_timeoutThread->wait(waitTime.count());
+        d->m_timeoutThread->wait(DefaultTerminateThreadTimeout);
 
         if (d->m_timeoutThread->isRunning()) {
             d->m_timeoutThread->terminate();
@@ -283,13 +279,13 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::getRequest(uint32_t id) -> Nedry
     return nullptr;
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::setInterval(std::chrono::milliseconds interval) -> bool {
-    d->m_interval = std::chrono::duration_cast<std::chrono::milliseconds>(interval);
+auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::setInterval(int interval) -> bool {
+    d->m_interval = interval;
 
     return true;
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::setTimeout(std::chrono::milliseconds timeout) -> bool {
+auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::setTimeout(int timeout) -> bool {
     d->m_timeout = timeout;
 
     return true;
@@ -299,16 +295,14 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::timeoutRequests() -> void {
     QMutexLocker locker(&d->m_requestsMutex);
     QMutableMapIterator<uint32_t, Nedrysoft::ICMPPingEngine::ICMPPingItem *> i(d->m_pingRequests);
 
-    std::chrono::high_resolution_clock::time_point startTime = std::chrono::high_resolution_clock::now();
-
     while (i.hasNext()) {
         i.next();
 
         auto pingItem = i.value();
 
-        std::chrono::duration<double> diff = startTime - pingItem->transmitTime();
+        auto elapsedTime = pingItem->elapsedTime();
 
-        if (diff > d->m_timeout) {
+        if ((elapsedTime/1e6) > d->m_timeout) {
             if (pingItem->lock()) {
                 if (!pingItem->serviced()) {
                     QHostAddress hostAddress;
@@ -321,7 +315,7 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::timeoutRequests() -> void {
                             Nedrysoft::RouteAnalyser::PingResult::ResultCode::NoReply,
                             hostAddress,
                             pingItem->transmitEpoch(),
-                            diff.count()/1000.0,
+                            pingItem->elapsedTime()/1e9,
                             pingItem->target());
 
                     Q_EMIT result(pingResult);
@@ -345,11 +339,11 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::loadConfiguration(QJsonObject co
     return false;
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::setEpoch(std::chrono::system_clock::time_point epoch) -> void {
+auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::setEpoch(QDateTime epoch) -> void {
     d->m_epoch = epoch;
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::epoch() -> std::chrono::system_clock::time_point {
+auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::epoch() -> QDateTime {
     return d->m_epoch;
 }
 
@@ -358,16 +352,17 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::version() -> Nedrysoft::Core::IP
 }
 
 void Nedrysoft::ICMPPingEngine::ICMPPingEngine::onPacketReceived(
-        std::chrono::time_point < std::chrono::high_resolution_clock > receiveTime,
+        QDateTime receiveTime,
         QByteArray receiveBuffer,
         QHostAddress receiveAddress ) {
 
     Nedrysoft::RouteAnalyser::PingResult::ResultCode resultCode =
-            Nedrysoft::RouteAnalyser::PingResult::ResultCode::NoReply;
+        Nedrysoft::RouteAnalyser::PingResult::ResultCode::NoReply;
 
     auto responsePacket = Nedrysoft::ICMPPacket::ICMPPacket::fromData(
-            receiveBuffer,
-            static_cast<Nedrysoft::ICMPPacket::IPVersion>(this->version()) );
+        receiveBuffer,
+        static_cast<Nedrysoft::ICMPPacket::IPVersion>(this->version())
+    );
 
     if (responsePacket.resultCode() == Nedrysoft::ICMPPacket::Invalid) {
         return;
@@ -387,15 +382,15 @@ void Nedrysoft::ICMPPingEngine::ICMPPingEngine::onPacketReceived(
         pingItem->lock();
 
         if (!pingItem->serviced()) {
-            std::chrono::duration<double> diff = receiveTime - pingItem->transmitTime();
 #pragma message("check /1000")
             auto pingResult = Nedrysoft::RouteAnalyser::PingResult(
-                    pingItem->sampleNumber(),
-                    resultCode,
-                    receiveAddress,
-                    pingItem->transmitEpoch(),
-                    diff.count()/1000.0,
-                    pingItem->target() );
+                pingItem->sampleNumber(),
+                resultCode,
+                receiveAddress,
+                pingItem->transmitEpoch(),
+                pingItem->elapsedTime(),
+                pingItem->target()
+            );
 
             Q_EMIT Nedrysoft::ICMPPingEngine::ICMPPingEngine::result(pingResult);
 
@@ -407,7 +402,7 @@ void Nedrysoft::ICMPPingEngine::ICMPPingEngine::onPacketReceived(
     }
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::interval() -> std::chrono::milliseconds {
+auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::interval() -> int {
     return d->m_transmitterWorker->interval();
 }
 
@@ -451,32 +446,33 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::singleShot(
     int sequenceId = 5555 + ttl;
 
     auto buffer = Nedrysoft::ICMPPacket::ICMPPacket::pingPacket(
-            id,
-            sequenceId,
-            52,
-            hostAddress,
-            static_cast<Nedrysoft::ICMPPacket::IPVersion>(version()));
+        id,
+        sequenceId,
+        52,
+        hostAddress,
+        static_cast<Nedrysoft::ICMPPacket::IPVersion>(version())
+    );
 
-    auto requestTime = std::chrono::high_resolution_clock::now();
     auto transmitEpoch = QDateTime::currentDateTime();
 
     writeSocket->sendto(buffer, hostAddress);
 
     QHostAddress receiveAddress;
 
-    QElapsedTimer timeoutTimer;
+    QElapsedTimer timer;
 
-    timeoutTimer.start();
+    timer.start();
 
-    while(timeoutTimer.elapsed()<(SecondsToMs(timeout))) {
-        auto remaining = DefaultReceiveTimeout-std::chrono::milliseconds(timeoutTimer.elapsed());
+    while(timer.elapsed()<(SecondsToMs(timeout))) {
+        auto remaining = DefaultReceiveTimeout-timer.elapsed();
 
-        if (remaining.count()<=0) {
+        if (remaining<=0) {
             return pingResult;
         }
 
         if (readSocket->recvfrom(receiveBuffer, receiveAddress, remaining)) {
-            auto responseTime = std::chrono::high_resolution_clock::now();
+            auto responseTime = QDateTime::currentDateTime();
+            auto roundTripTime = timer.nsecsElapsed();
 
             Nedrysoft::RouteAnalyser::PingResult::ResultCode resultCode;
 
@@ -505,14 +501,12 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingEngine::singleShot(
                 resultCode = Nedrysoft::RouteAnalyser::PingResult::ResultCode::TimeExceeded;
             }
 
-            auto roundTripTime = std::chrono::duration<double, std::milli>(responseTime-requestTime);
-
             pingResult = Nedrysoft::RouteAnalyser::PingResult(
                 0,
                 resultCode,
                 receiveAddress,
                 transmitEpoch,
-                roundTripTime.count()/1000.0,
+                roundTripTime/1e9,
                 nullptr
             );
 

--- a/src/components/ICMPPingEngine/ICMPPingEngine.h
+++ b/src/components/ICMPPingEngine/ICMPPingEngine.h
@@ -27,8 +27,9 @@
 #include <IInterface>
 #include <IPingEngine>
 #include <IPingEngineFactory>
+#include <QElapsedTimer>
+#include <QDateTime>
 #include <memory>
-#include <chrono>
 
 namespace Nedrysoft { namespace ICMPPingEngine {
     class ICMPPingEngineData;
@@ -62,31 +63,31 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              *
              * @see         Nedrysoft::RouteAnalyser::IPingEngine::setInterval
              *
-             * @param[in]   interval interval time.
+             * @param[in]   interval interval time in milliseconds.
              *
              * @returns     returns true on success; otherwise false.
              */
-            auto setInterval(std::chrono::milliseconds interval) -> bool override;
+            auto setInterval(int interval) -> bool override;
 
             /**
              * @brief       Returns the interval set on the engine.
              *
              * @see         Nedrysoft::RouteAnalyser::IPingEngine::interval
              *
-             * @returns     the interval.
+             * @returns     the interval time in milliseconds.
              */
-            auto interval() -> std::chrono::milliseconds override;
+            auto interval() -> int override;
 
             /**
              * @brief       Sets the reply timeout for this engine instance.
              *
              * @see         Nedrysoft::RouteAnalyser::IPingEngine::setTimeout
              *
-             * @param[in]   timeout the amount of time before we consider that the packet was lost.
+             * @param[in]   timeout the number of milliseconds before we consider that the packet was lost.
              *
              * @returns     true on success; otherwise false.
              */
-            auto setTimeout(std::chrono::milliseconds timeout) -> bool override;
+            auto setTimeout(int timeout) -> bool override;
 
             /**
              * @brief       Starts ping operations for this engine instance.
@@ -163,7 +164,7 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              *
              * @returns     the time epoch.
              */
-            auto epoch() -> std::chrono::system_clock::time_point override;
+            auto epoch() -> QDateTime override;
 
             /**
              * @brief       Returns the list of ping targets for the engine.
@@ -202,7 +203,7 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              * @param[in]   receiveAddress the IP address that the response came from (may be different to target).
              */
             Q_SLOT void onPacketReceived(
-                    std::chrono::time_point<std::chrono::high_resolution_clock> receiveTime,
+                    QDateTime receiveTime,
                     QByteArray receiveBuffer, QHostAddress receiveAddress );
 
         protected:
@@ -256,7 +257,7 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              *
              * @param[in]   epoch is the epoch.
              */
-            auto setEpoch(std::chrono::system_clock::time_point epoch) -> void;
+            auto setEpoch(QDateTime epoch) -> void;
 
             /**
              * @brief       Returns the IP version of the engine.

--- a/src/components/ICMPPingEngine/ICMPPingEngine.h
+++ b/src/components/ICMPPingEngine/ICMPPingEngine.h
@@ -284,6 +284,7 @@ namespace Nedrysoft { namespace ICMPPingEngine {
 
             friend class ICMPPingTransmitter;
             friend class ICMPPingTimeout;
+            friend class ICMPPingReceiverWorker;
 
         protected:
             //! @cond

--- a/src/components/ICMPPingEngine/ICMPPingEngine.h
+++ b/src/components/ICMPPingEngine/ICMPPingEngine.h
@@ -198,13 +198,15 @@ namespace Nedrysoft { namespace ICMPPingEngine {
             /**
              * @brief       Called when a ICMP packet is available for processing.
              *
-             * @param[in]   receiveTime the time at which the packet was received.
+             * @param[in]   receiveTimer a timer started when the packet was received.
              * @param[in]   receiveBuffer the actual packet data.
              * @param[in]   receiveAddress the IP address that the response came from (may be different to target).
              */
             Q_SLOT void onPacketReceived(
-                    QDateTime receiveTime,
-                    QByteArray receiveBuffer, QHostAddress receiveAddress );
+                QElapsedTimer receiveTimer,
+                QByteArray receiveBuffer,
+                QHostAddress receiveAddress
+            );
 
         protected:
             /**

--- a/src/components/ICMPPingEngine/ICMPPingEngine.h
+++ b/src/components/ICMPPingEngine/ICMPPingEngine.h
@@ -142,9 +142,10 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              * @returns     the result of the ping.
              */
             auto singleShot(
-                    QHostAddress hostAddress,
-                    int ttl,
-                    double timeout ) -> Nedrysoft::RouteAnalyser::PingResult override;
+                QHostAddress hostAddress,
+                int ttl,
+                double timeout
+            ) -> Nedrysoft::RouteAnalyser::PingResult override;
 
             /**
              * @brief       Removes a ping target from this engine instance.

--- a/src/components/ICMPPingEngine/ICMPPingItem.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingItem.cpp
@@ -52,7 +52,7 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingItem::sequenceId() -> uint16_t {
 
 auto Nedrysoft::ICMPPingEngine::ICMPPingItem::setTransmitTime(
         std::chrono::high_resolution_clock::time_point time,
-        std::chrono::system_clock::time_point epoch) -> void {
+        QDateTime epoch) -> void {
 
     m_transmitTime = time;
     m_transmitEpoch = epoch;
@@ -82,7 +82,7 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingItem::transmitTime() -> std::chrono::hig
     return m_transmitTime;
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingItem::transmitEpoch() -> std::chrono::system_clock::time_point {
+auto Nedrysoft::ICMPPingEngine::ICMPPingItem::transmitEpoch() -> QDateTime {
     return m_transmitEpoch;
 }
 

--- a/src/components/ICMPPingEngine/ICMPPingItem.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingItem.cpp
@@ -50,12 +50,14 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingItem::sequenceId() -> uint16_t {
     return m_sequenceId;
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingItem::setTransmitTime(
-        std::chrono::high_resolution_clock::time_point time,
-        QDateTime epoch) -> void {
+auto Nedrysoft::ICMPPingEngine::ICMPPingItem::startTimer() -> void {
+    m_elapsedTimer.restart();
+    m_transmitEpoch = QDateTime::currentDateTime();
+}
 
-    m_transmitTime = time;
-    m_transmitEpoch = epoch;
+#pragma message("not noEDE")
+auto Nedrysoft::ICMPPingEngine::ICMPPingItem::stopTimer() -> void {
+    m_elapsedTime = m_elapsedTimer.nsecsElapsed();
 }
 
 auto Nedrysoft::ICMPPingEngine::ICMPPingItem::setServiced(bool serviced) -> void {
@@ -78,8 +80,8 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingItem::target() -> Nedrysoft::ICMPPingEng
     return m_target;
 }
 
-auto Nedrysoft::ICMPPingEngine::ICMPPingItem::transmitTime() -> std::chrono::high_resolution_clock::time_point {
-    return m_transmitTime;
+auto Nedrysoft::ICMPPingEngine::ICMPPingItem::elapsedTime() -> double {
+    return static_cast<double>(m_elapsedTimer.nsecsElapsed())/1e9;
 }
 
 auto Nedrysoft::ICMPPingEngine::ICMPPingItem::transmitEpoch() -> QDateTime {

--- a/src/components/ICMPPingEngine/ICMPPingItem.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingItem.cpp
@@ -81,7 +81,7 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingItem::target() -> Nedrysoft::ICMPPingEng
 }
 
 auto Nedrysoft::ICMPPingEngine::ICMPPingItem::elapsedTime() -> double {
-    return static_cast<double>(m_elapsedTimer.nsecsElapsed())/1e9;
+    return static_cast<double>(m_elapsedTimer.nsecsElapsed())/static_cast<double>(1e9);
 }
 
 auto Nedrysoft::ICMPPingEngine::ICMPPingItem::transmitEpoch() -> QDateTime {

--- a/src/components/ICMPPingEngine/ICMPPingItem.h
+++ b/src/components/ICMPPingEngine/ICMPPingItem.h
@@ -24,6 +24,7 @@
 #ifndef PINGNOO_COMPONENTS_ICMPPINGENGINE_ICMPPINGITEM_H
 #define PINGNOO_COMPONENTS_ICMPPINGENGINE_ICMPPINGITEM_H
 
+#include <QDateTime>
 #include <QMutex>
 #include <QObject>
 #include <chrono>
@@ -136,7 +137,7 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              */
             auto setTransmitTime(
                     std::chrono::high_resolution_clock::time_point time,
-                    std::chrono::system_clock::time_point epoch ) -> void;
+                    QDateTime epoch ) -> void;
 
             /**
              * @brief       Returns the time at which the request was transmitted.
@@ -150,7 +151,7 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              *
              * @returns     the epoch when the request was sent.
              */
-            auto transmitEpoch() -> std::chrono::system_clock::time_point;
+            auto transmitEpoch() -> QDateTime;
 
             /**
              * @brief       Locks the item for exclusive access.
@@ -168,7 +169,7 @@ namespace Nedrysoft { namespace ICMPPingEngine {
             //! @cond
 
             std::chrono::high_resolution_clock::time_point m_transmitTime;
-            std::chrono::system_clock::time_point m_transmitEpoch;
+            QDateTime m_transmitEpoch;
 
             uint16_t m_id;
             uint16_t m_sequenceId;

--- a/src/components/ICMPPingEngine/ICMPPingItem.h
+++ b/src/components/ICMPPingEngine/ICMPPingItem.h
@@ -25,9 +25,9 @@
 #define PINGNOO_COMPONENTS_ICMPPINGENGINE_ICMPPINGITEM_H
 
 #include <QDateTime>
+#include <QElapsedTimer>
 #include <QMutex>
 #include <QObject>
-#include <chrono>
 
 namespace Nedrysoft { namespace ICMPPingEngine {
     class ICMPPingTarget;
@@ -130,21 +130,31 @@ namespace Nedrysoft { namespace ICMPPingEngine {
             auto target() -> Nedrysoft::ICMPPingEngine::ICMPPingTarget *;
 
             /**
-             * @brief       Sets the time at which the request was transmitted.
-             *
-             * @param[in]   time the high resolution clock time.
-             * @param[in]   epoch the epoch for transmission.
+             * @brief       Records the transmission date/time and starts the round trip timer.
              */
-            auto setTransmitTime(
-                    std::chrono::high_resolution_clock::time_point time,
-                    QDateTime epoch ) -> void;
+            auto startTimer() -> void;
 
             /**
-             * @brief       Returns the time at which the request was transmitted.
+             * @brief       Records the current elapsed time.
              *
-             * @returns     the high resolution clock time when the request was sent.
+             * @note        This doesn't actually stop the timer, that is not possible with QElapsedTimer, instead
+             *              it just records the current elapsed time in a variable.
              */
-            auto transmitTime(void) -> std::chrono::high_resolution_clock::time_point;
+            auto stopTimer()-> void;
+
+            /**
+             * @brief       Returns the current time elapsed from transmission.
+             *
+             * @returns     the time in milliseconds.
+             */
+            auto elapsedTime(void) -> double;
+
+            /**
+             * @brief       Returns the the round trip time from the request to response.
+             *
+             * @returns     the time in seconds.
+             */
+            auto roundTripTime() -> double;
 
             /**
              * @brief       Returns the epoch at which the request was transmitted.
@@ -168,8 +178,10 @@ namespace Nedrysoft { namespace ICMPPingEngine {
         private:
             //! @cond
 
-            std::chrono::high_resolution_clock::time_point m_transmitTime;
+            QElapsedTimer m_elapsedTimer;
             QDateTime m_transmitEpoch;
+
+            int64_t m_elapsedTime;
 
             uint16_t m_id;
             uint16_t m_sequenceId;

--- a/src/components/ICMPPingEngine/ICMPPingReceiverWorker.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingReceiverWorker.cpp
@@ -79,8 +79,6 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::getInstance(bool returnN
 
     instance->m_receiverThread = new QThread;
 
-    qRegisterMetaType<std::chrono::time_point<std::chrono::high_resolution_clock>>();
-
     instance->moveToThread(instance->m_receiverThread);
 
     connect(instance->m_receiverThread, &QThread::started, instance, &Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::doWork);
@@ -104,12 +102,17 @@ void Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::doWork() {
     m_isRunning = true;
 
     while (QThread::currentThread()->isRunning() && (m_isRunning)) {
+        QElapsedTimer receiveTimer;
+
+        receiveTimer.restart();
         auto result = m_socket->recvfrom(receiveBuffer, receiveAddress, DefaultReplyTimeout);
+
+
 
         if (result!=-1) {
             SPDLOG_TRACE("ICMP Packet Received");
 
-            Q_EMIT packetReceived(QDateTime::currentDateTime(), receiveBuffer, receiveAddress);
+            Q_EMIT packetReceived(receiveTimer, receiveBuffer, receiveAddress);
         }
     }
 }

--- a/src/components/ICMPPingEngine/ICMPPingReceiverWorker.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingReceiverWorker.cpp
@@ -32,12 +32,9 @@
 #include <QHostAddress>
 #include <QThread>
 #include <QtEndian>
-#include <chrono>
 #include <spdlog/spdlog.h>
 
-using namespace std::chrono_literals;
-
-constexpr auto DefaultReplyTimeout = 1s;
+constexpr auto DefaultReplyTimeout = 1000;
 
 Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::ICMPPingReceiverWorker() :
         m_engine(nullptr),
@@ -97,8 +94,10 @@ auto Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::getInstance(bool returnN
 
 void Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::doWork() {
     QByteArray receiveBuffer;
+
     m_socket =  Nedrysoft::ICMPSocket::ICMPSocket::createReadSocket(
-            static_cast<Nedrysoft::ICMPSocket::IPVersion>(Nedrysoft::ICMPSocket::V4));
+        static_cast<Nedrysoft::ICMPSocket::IPVersion>(Nedrysoft::ICMPSocket::V4)
+    );
 
     QHostAddress receiveAddress;
 
@@ -107,12 +106,10 @@ void Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::doWork() {
     while (QThread::currentThread()->isRunning() && (m_isRunning)) {
         auto result = m_socket->recvfrom(receiveBuffer, receiveAddress, DefaultReplyTimeout);
 
-        std::chrono::time_point<std::chrono::high_resolution_clock> receiveTime = std::chrono::high_resolution_clock::now();
-
         if (result!=-1) {
             SPDLOG_TRACE("ICMP Packet Received");
 
-            Q_EMIT packetReceived(receiveTime, receiveBuffer, receiveAddress);
+            Q_EMIT packetReceived(QDateTime::currentDateTime(), receiveBuffer, receiveAddress);
         }
     }
 }

--- a/src/components/ICMPPingEngine/ICMPPingReceiverWorker.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingReceiverWorker.cpp
@@ -104,10 +104,9 @@ void Nedrysoft::ICMPPingEngine::ICMPPingReceiverWorker::doWork() {
     while (QThread::currentThread()->isRunning() && (m_isRunning)) {
         QElapsedTimer receiveTimer;
 
-        receiveTimer.restart();
         auto result = m_socket->recvfrom(receiveBuffer, receiveAddress, DefaultReplyTimeout);
 
-
+        receiveTimer.restart();
 
         if (result!=-1) {
             SPDLOG_TRACE("ICMP Packet Received");

--- a/src/components/ICMPPingEngine/ICMPPingReceiverWorker.h
+++ b/src/components/ICMPPingEngine/ICMPPingReceiverWorker.h
@@ -25,7 +25,6 @@
 #define PINGNOO_COMPONENTS_ICMPPINGENGINE_ICMPPINGRECEIVERWORKER_H
 
 #include <QObject>
-#include <chrono>
 #include <QByteArray>
 #include <QHostAddress>
 #include <QThread>
@@ -76,12 +75,12 @@ namespace Nedrysoft { namespace ICMPPingEngine {
             /**
              * @brief       This signal is emitted when an ICMP packet has been received.
              *
-             * @param[in]   receiveTime the time at which the reception occurred.
+             * @param[in]   receiveTimer a timer started from when the packet was received.
              * @param[in]   receiveBuffer the packet data.
              * @param[in]   receiveAddress the address the packet was received from (this may differ from the target).
              */
             Q_SIGNAL void packetReceived(
-                QDateTime receiveTime,
+                QElapsedTimer receiveTimer,
                 QByteArray receiveBuffer,
                 QHostAddress receiveAddress
             );
@@ -108,9 +107,5 @@ namespace Nedrysoft { namespace ICMPPingEngine {
             //! @endcond
     };
 }}
-
-#if (QT_VERSION_MAJOR<6)
-Q_DECLARE_METATYPE(std::chrono::time_point<std::chrono::high_resolution_clock>)
-#endif
 
 #endif // PINGNOO_COMPONENTS_ICMPPINGENGINE_ICMPPINGRECEIVERWORKER_H

--- a/src/components/ICMPPingEngine/ICMPPingReceiverWorker.h
+++ b/src/components/ICMPPingEngine/ICMPPingReceiverWorker.h
@@ -26,6 +26,7 @@
 
 #include <QObject>
 #include <QByteArray>
+#include <QElapsedTimer>
 #include <QHostAddress>
 #include <QThread>
 

--- a/src/components/ICMPPingEngine/ICMPPingReceiverWorker.h
+++ b/src/components/ICMPPingEngine/ICMPPingReceiverWorker.h
@@ -81,9 +81,10 @@ namespace Nedrysoft { namespace ICMPPingEngine {
              * @param[in]   receiveAddress the address the packet was received from (this may differ from the target).
              */
             Q_SIGNAL void packetReceived(
-                    std::chrono::time_point < std::chrono::high_resolution_clock > receiveTime,
-                    QByteArray receiveBuffer,
-                    QHostAddress receiveAddress);
+                QDateTime receiveTime,
+                QByteArray receiveBuffer,
+                QHostAddress receiveAddress
+            );
 
             friend class ICMPPingEngine;
             friend class ICMPPingEngineFactory;

--- a/src/components/ICMPPingEngine/ICMPPingTimeout.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingTimeout.cpp
@@ -41,6 +41,6 @@ void Nedrysoft::ICMPPingEngine::ICMPPingTimeout::doWork() {
     while (m_isRunning) {
         m_engine->timeoutRequests();
 
-        QThread::msleeo(DefaultSleepTime);
+        QThread::msleep(DefaultSleepTime);
     }
 }

--- a/src/components/ICMPPingEngine/ICMPPingTimeout.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingTimeout.cpp
@@ -26,11 +26,8 @@
 #include "ICMPPingEngine.h"
 
 #include <QThread>
-#include <thread>
 
-using namespace std::chrono_literals;
-
-constexpr auto DefaultSleepTime = 1s;
+constexpr auto DefaultSleepTime = 1000;
 
 Nedrysoft::ICMPPingEngine::ICMPPingTimeout::ICMPPingTimeout(Nedrysoft::ICMPPingEngine::ICMPPingEngine *engine) :
         m_engine(engine),
@@ -44,6 +41,6 @@ void Nedrysoft::ICMPPingEngine::ICMPPingTimeout::doWork() {
     while (m_isRunning) {
         m_engine->timeoutRequests();
 
-        std::this_thread::sleep_for(DefaultSleepTime);
+        QThread::msleeo(DefaultSleepTime);
     }
 }

--- a/src/components/ICMPPingEngine/ICMPPingTransmitter.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingTransmitter.cpp
@@ -88,7 +88,7 @@ void Nedrysoft::ICMPPingEngine::ICMPPingTransmitter::doWork() {
 
             m_engine->addRequest(pingItem);
 
-            pingItem->setTransmitTime(std::chrono::high_resolution_clock::now(), std::chrono::system_clock::now());
+            pingItem->setTransmitTime(std::chrono::high_resolution_clock::now(), QDateTime::currentDateTime());
 
             auto buffer = Nedrysoft::ICMPPacket::ICMPPacket::pingPacket(
                     target->id(),

--- a/src/components/ICMPPingEngine/ICMPPingTransmitter.cpp
+++ b/src/components/ICMPPingEngine/ICMPPingTransmitter.cpp
@@ -92,9 +92,9 @@ void Nedrysoft::ICMPPingEngine::ICMPPingTransmitter::doWork() {
                     target->hostAddress(),
                     static_cast<Nedrysoft::ICMPPacket::IPVersion>(m_engine->version()) );
 
-            pingItem->startTimer();
-
             auto result = socket->sendto(buffer, target->hostAddress());
+
+            pingItem->startTimer();
 
             SPDLOG_TRACE(
                     QString("Sent ping to %1 (TTL=%2, Result=%3)")
@@ -112,7 +112,6 @@ void Nedrysoft::ICMPPingEngine::ICMPPingTransmitter::doWork() {
         auto elapsedTime = elapsedTimer.elapsed();
 
         if (elapsedTime < m_interval) {
-            qDebug() << "sleepy" << elapsedTime << m_interval;
             QThread::msleep(m_interval - elapsedTime);
         }
 

--- a/src/components/ICMPPingEngine/ICMPPingTransmitter.h
+++ b/src/components/ICMPPingEngine/ICMPPingTransmitter.h
@@ -28,7 +28,6 @@
 
 #include <QMutex>
 #include <QObject>
-#include <chrono>
 
 namespace Nedrysoft { namespace ICMPPingEngine {
     class ICMPPingEngine;
@@ -62,16 +61,16 @@ namespace Nedrysoft { namespace ICMPPingEngine {
             /**
              * @brief       Sets the interval between a set of pings.
              *
-             * @param[in]   interval the interval.
+             * @param[in]   interval the interval in milliseconds.
              */
-            auto setInterval(std::chrono::milliseconds interval) -> bool;
+            auto setInterval(int interval) -> bool;
 
             /**
              * @brief       Returns the ping interval.
              *
-             * @returns     the interval.
+             * @returns     the interval in milliseconds.
              */
-            auto interval() -> std::chrono::milliseconds;
+            auto interval() -> int;
 
             /**
              * @brief       Adds a ping target to the transmitter.
@@ -101,13 +100,13 @@ namespace Nedrysoft { namespace ICMPPingEngine {
         private:
             //! @cond
 
-            std::chrono::milliseconds m_interval = {};
+            int m_interval;
             Nedrysoft::ICMPPingEngine::ICMPPingEngine *m_engine;
 
             QList<Nedrysoft::ICMPPingEngine::ICMPPingTarget *> m_targets;
             QMutex m_targetsMutex;
 
-            std::chrono::high_resolution_clock::time_point m_epoch;
+            QDateTime m_epoch;
 
             static QMutex m_sequenceMutex;
             static uint16_t m_sequenceId;

--- a/src/components/JitterPlot/JitterBackgroundLayer.h
+++ b/src/components/JitterPlot/JitterBackgroundLayer.h
@@ -25,7 +25,6 @@
 #define NEDRYSOFT_JITTERPLOT_JITTERBACKGROUNDLAYER_H
 
 #include "QCustomPlot/qcustomplot.h"
-#include "chrono"
 
 namespace Nedrysoft { namespace JitterPlot {
     /**

--- a/src/components/PingCommandPingEngine/PingCommandPingEngine.cpp
+++ b/src/components/PingCommandPingEngine/PingCommandPingEngine.cpp
@@ -35,7 +35,6 @@ constexpr auto DefaultReceiveTimeout = 1000;
 constexpr auto DefaultTerminateThreadTimeout = 5000;
 constexpr auto DefaultTTL = 64;
 
-constexpr auto NanosecondsInMillisecond = 1.0e6;
 constexpr auto PacketLostRegularExpression = R"(100% packet loss)";
 constexpr auto TtlExceededRegularExpression = R"(From\ (?<ip>[\d\.]*)\ .*exceeded)";
 
@@ -102,7 +101,7 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::setTimeout(int tim
 }
 
 auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::epoch() -> QDateTime {
-    return QDateTime::currentSystemTime();
+    return QDateTime::currentDateTime();
 }
 
 auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::saveConfiguration() -> QJsonObject {
@@ -159,7 +158,7 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::singleShot(
 
     pingProcess.waitForFinished();
 
-    auto roundTripTime = static_cast<double>(time.nsecsElapsed()) / NanosecondsInMillisecond;
+    auto roundTripTime = timer.elapsed()/1e9;
 
     auto commandOutput = pingProcess.readAll();
 

--- a/src/components/PingCommandPingEngine/PingCommandPingEngine.cpp
+++ b/src/components/PingCommandPingEngine/PingCommandPingEngine.cpp
@@ -30,12 +30,9 @@
 #include <QProcess>
 #include <QRegularExpression>
 #include <QThread>
-#include <chrono>
 
-using namespace std::chrono_literals;
-
-constexpr auto DefaultReceiveTimeout = 1s;
-constexpr auto DefaultTerminateThreadTimeout = 5s;
+constexpr auto DefaultReceiveTimeout = 1000;
+constexpr auto DefaultTerminateThreadTimeout = 5000;
 constexpr auto DefaultTTL = 64;
 
 constexpr auto NanosecondsInMillisecond = 1.0e6;
@@ -62,9 +59,10 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::addTarget(
         int ttl ) -> Nedrysoft::RouteAnalyser::IPingTarget * {
 
     auto newTarget = new Nedrysoft::PingCommandPingEngine::PingCommandPingTarget(
-            this,
-            hostAddress,
-            ttl );
+        this,
+        hostAddress,
+        ttl
+    );
 
     m_pingTargets.append(newTarget);
 
@@ -87,24 +85,24 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::stop() -> bool {
     return true;
 }
 
-auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::setInterval(std::chrono::milliseconds interval) -> bool {
+auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::setInterval(int interval) -> bool {
     m_interval = interval;
 
     return true;
 }
 
-auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::interval() -> std::chrono::milliseconds {
+auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::interval() -> int {
     return m_interval;
 }
 
-auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::setTimeout(std::chrono::milliseconds timeout) -> bool {
+auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::setTimeout(int timeout) -> bool {
     Q_UNUSED(timeout)
 
     return true;
 }
 
-auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::epoch() -> std::chrono::system_clock::time_point {
-    return std::chrono::system_clock::now();
+auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::epoch() -> QDateTime {
+    return QDateTime::currentSystemTime();
 }
 
 auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::saveConfiguration() -> QJsonObject {
@@ -141,10 +139,8 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::singleShot(
         double timeout) -> Nedrysoft::RouteAnalyser::PingResult {
 
     QProcess pingProcess;
-    qint64 started, finished;
     QElapsedTimer timer;
-
-    std::chrono::system_clock::time_point epoch;
+    QDateTime epoch;
 
     auto pingArguments = QStringList() <<
                                        "-W" << QString("%1").arg(timeout) <<
@@ -157,15 +153,13 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::singleShot(
 
     pingProcess.waitForStarted();
 
-    started = timer.nsecsElapsed();
+    timer.restart();
 
-    epoch = std::chrono::system_clock::now();
+    epoch = QDateTime::currentDateTime();
 
     pingProcess.waitForFinished();
 
-    finished = timer.nsecsElapsed();
-
-    auto roundTripTime = static_cast<double>(finished - started) / NanosecondsInMillisecond;
+    auto roundTripTime = static_cast<double>(time.nsecsElapsed()) / NanosecondsInMillisecond;
 
     auto commandOutput = pingProcess.readAll();
 
@@ -176,12 +170,13 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::singleShot(
 
     if (pingProcess.exitCode() == 0) {
         pingResult = Nedrysoft::RouteAnalyser::PingResult(
-                0,
-                Nedrysoft::RouteAnalyser::PingResult::ResultCode::Ok,
-                hostAddress,
-                epoch,
-                std::chrono::duration<double, std::milli>(roundTripTime),
-                nullptr);
+            0,
+            Nedrysoft::RouteAnalyser::PingResult::ResultCode::Ok,
+            hostAddress,
+            epoch,
+            roundTripTime,
+            nullptr
+        );
 
     } else {
         auto ttlExceededMatch = ttlExceededRegEx.match(commandOutput);
@@ -189,20 +184,22 @@ auto Nedrysoft::PingCommandPingEngine::PingCommandPingEngine::singleShot(
 
         if (ttlExceededMatch.hasMatch()) {
             pingResult = Nedrysoft::RouteAnalyser::PingResult(
-                    0,
-                    Nedrysoft::RouteAnalyser::PingResult::ResultCode::TimeExceeded,
-                    QHostAddress(ttlExceededMatch.captured("ip")),
-                    epoch,
-                    std::chrono::duration<double, std::milli>(roundTripTime),
-                    nullptr);
+                0,
+                Nedrysoft::RouteAnalyser::PingResult::ResultCode::TimeExceeded,
+                QHostAddress(ttlExceededMatch.captured("ip")),
+                epoch,
+                roundTripTime,
+                nullptr
+            );
         } else if (packetLostMatch.hasMatch()) {
             pingResult = Nedrysoft::RouteAnalyser::PingResult(
-                    0,
-                    Nedrysoft::RouteAnalyser::PingResult::ResultCode::NoReply,
-                    QHostAddress(packetLostMatch.captured("ip")),
-                    epoch,
-                    std::chrono::duration<double, std::milli>(roundTripTime),
-                    nullptr);
+                0,
+                Nedrysoft::RouteAnalyser::PingResult::ResultCode::NoReply,
+                QHostAddress(packetLostMatch.captured("ip")),
+                epoch,
+                roundTripTime,
+                nullptr
+            );
         } else {
             // some other error
         }

--- a/src/components/PingCommandPingEngine/PingCommandPingEngine.h
+++ b/src/components/PingCommandPingEngine/PingCommandPingEngine.h
@@ -28,8 +28,6 @@
 #include <IPingEngine>
 #include <IPingEngineFactory>
 
-#include <chrono>
-
 namespace Nedrysoft { namespace PingCommandPingEngine {
     class PingCommandPingTarget;
 
@@ -60,11 +58,11 @@ namespace Nedrysoft { namespace PingCommandPingEngine {
              *
              * @see         Nedrysoft::RouteAnalyser::IPingEngine::setInterval
              *
-             * @param[in]   interval interval time.
+             * @param[in]   interval the interval between pings in milliseconds.
              *
              * @returns     returns true on success; otherwise false.
              */
-            auto setInterval(std::chrono::milliseconds interval) -> bool override;
+            auto setInterval(int interval) -> bool override;
 
             /**
              * @brief       Returns the measurement interval.
@@ -73,18 +71,18 @@ namespace Nedrysoft { namespace PingCommandPingEngine {
              *
              * @returns     returns the measurement interval.
              */
-            auto interval() -> std::chrono::milliseconds override;
+            auto interval() -> int override;
 
             /**
              * @brief       Sets the reply timeout for this engine instance.
              *
              * @see         Nedrysoft::RouteAnalyser::IPingEngine::setTimeout
              *
-             * @param[in]   timeout the amount of time before we consider that the packet was lost.
+             * @param[in]   timeout the time in milliseconds to wait for a reply.
              *
              * @returns     true on success; otherwise false.
              */
-            auto setTimeout(std::chrono::milliseconds timeout) -> bool override;
+            auto setTimeout(int timeout) -> bool override;
 
             /**
              * @brief       Starts ping operations for this engine instance.
@@ -145,7 +143,7 @@ namespace Nedrysoft { namespace PingCommandPingEngine {
              *
              * @returns     the time epoch.
              */
-            auto epoch() -> std::chrono::system_clock::time_point override;
+            auto epoch() -> QDateTime;
 
             /**
              * @brief       Returns the list of ping targets for the engine.
@@ -166,9 +164,10 @@ namespace Nedrysoft { namespace PingCommandPingEngine {
              * @returns     the result of the ping.
              */
             auto singleShot(
-                    QHostAddress hostAddress,
-                    int ttl,
-                    double timeout ) -> Nedrysoft::RouteAnalyser::PingResult override;
+                QHostAddress hostAddress,
+                int ttl,
+                double timeout
+            ) -> Nedrysoft::RouteAnalyser::PingResult override;
 
         public:
             /**
@@ -201,7 +200,7 @@ namespace Nedrysoft { namespace PingCommandPingEngine {
 
             QList<PingCommandPingTarget *> m_pingTargets;
 
-            std::chrono::milliseconds m_interval;
+            int m_interval;
 
             //! @endcond
     };

--- a/src/components/PingCommandPingEngine/PingCommandPingTarget.h
+++ b/src/components/PingCommandPingEngine/PingCommandPingTarget.h
@@ -57,9 +57,10 @@ namespace Nedrysoft { namespace PingCommandPingEngine {
              * @param[in]   ttl the TTL to be used in the ping.
              */
             PingCommandPingTarget(
-                    Nedrysoft::PingCommandPingEngine::PingCommandPingEngine *engine,
-                    QHostAddress hostAddress,
-                    int ttl = 0 );
+                Nedrysoft::PingCommandPingEngine::PingCommandPingEngine *engine,
+                QHostAddress hostAddress,
+                int ttl = 0
+            );
 
             /**
              * @brief       Destroys the PingCommandPingTarget.

--- a/src/components/RouteAnalyser/GraphLatencyLayer.cpp
+++ b/src/components/RouteAnalyser/GraphLatencyLayer.cpp
@@ -32,12 +32,6 @@
 #include "ColourManager.h"
 
 #include <cassert>
-#include <chrono>
-
-using namespace std::chrono_literals;
-
-constexpr auto DefaultWarningLatency = 200.0;
-constexpr auto DefaultCriticalLatency = 500.0;
 
 constexpr auto RoundedRectangleRadius = 10;
 constexpr auto TinyNumber = 0.0001;
@@ -47,15 +41,12 @@ constexpr auto LatencyStopLineColour = Qt::black;
 constexpr auto UnusedRemovalTime = 5;
 
 //! @cond
-QMap<QString, QPixmap> Nedrysoft::RouteAnalyser::GraphLatencyLayer::m_buffers;// = QMap<QString, QPixmap>();
+QMap<QString, QPixmap> Nedrysoft::RouteAnalyser::GraphLatencyLayer::m_buffers;
 QMap<QString, uint64_t> Nedrysoft::RouteAnalyser::GraphLatencyLayer::m_age;
 //! @endcond
 
 Nedrysoft::RouteAnalyser::GraphLatencyLayer::GraphLatencyLayer(QCustomPlot *customPlot) :
-        QCPItemRect(customPlot),
-        m_warningLatency(DefaultWarningLatency),
-        m_criticalLatency(DefaultCriticalLatency),
-        m_useGradient(true) {
+        QCPItemRect(customPlot) {
 
 }
 
@@ -92,16 +83,18 @@ auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::draw(QCPPainter *painter) -> v
     auto rect = parentPlot()->axisRect()->rect();
     auto topLeft = rect.topLeft();
 
-    auto idealStop = m_warningLatency/(graphMaxLatency*1000.0);
-    auto warningStop = m_criticalLatency/(graphMaxLatency*1000.0);
-
-
-    qDebug() << idealStop << m_warningLatency << graphMaxLatency;
     auto latencySettings = Nedrysoft::RouteAnalyser::LatencySettings::getInstance();
 
     assert(latencySettings!=nullptr);
 
-    QString bufferName = QString("%1_%2_%3_%4_%5").arg(rect.size().width()).arg(rect.size().height()).arg(idealStop).arg(warningStop).arg(m_useGradient);
+    auto idealStop = latencySettings->warningValue()/graphMaxLatency;
+    auto warningStop = latencySettings->criticalValue()/graphMaxLatency;
+
+    QString bufferName = QString("%1_%2_%3_%4_%5")
+            .arg(rect.size().width())
+            .arg(rect.size().height())
+            .arg(idealStop)
+            .arg(warningStop).arg(latencySettings->gradientFill());
 
     if (!m_buffers.contains(bufferName)) {
         rect.translate(-rect.left(), -rect.top());
@@ -121,7 +114,7 @@ auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::draw(QCPPainter *painter) -> v
                     graphGradient.setColorAt(0, QColor(latencySettings->idealColour()));
                     graphGradient.setColorAt(1, QColor(latencySettings->warningColour()));
 
-                    if (!m_useGradient) {
+                    if (!latencySettings->gradientFill()) {
                         graphGradient.setColorAt(idealStop, QColor(latencySettings->warningColour()));
                         graphGradient.setColorAt(idealStop-TinyNumber, QColor(latencySettings->idealColour()));
                     }
@@ -132,7 +125,7 @@ auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::draw(QCPPainter *painter) -> v
                 graphGradient.setColorAt(warningStop, QColor(latencySettings->criticalColour()));
                 graphGradient.setColorAt(1, QColor(latencySettings->criticalColour()));
 
-                if (!m_useGradient) {
+                if (!latencySettings->gradientFill()) {
                     graphGradient.setColorAt(idealStop-TinyNumber, QColor(latencySettings->idealColour()));
                     graphGradient.setColorAt(warningStop-TinyNumber, QColor(latencySettings->warningColour()));
                 }
@@ -147,12 +140,14 @@ auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::draw(QCPPainter *painter) -> v
 
         if (idealStop < 1) {
             startPoint = QPointF(
-                    floatingPointRect.left(),
-                    floatingPointRect.bottom()-(idealStop*floatingPointRect.height()) );
+                floatingPointRect.left(),
+                floatingPointRect.bottom()-(idealStop*floatingPointRect.height())
+            );
 
             endPoint = QPointF(
-                    floatingPointRect.right(),
-                    floatingPointRect.bottom()-(idealStop*floatingPointRect.height()) );
+                floatingPointRect.right(),
+                floatingPointRect.bottom()-(idealStop*floatingPointRect.height())
+            );
         }
 
         auto pen = QPen(Qt::DashLine);
@@ -164,11 +159,11 @@ auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::draw(QCPPainter *painter) -> v
         bufferPainter.drawLine(startPoint, endPoint);
 
         if (warningStop < 1) {
-            startPoint = QPointF(rect.left(), floatingPointRect.bottom()-(warningStop*floatingPointRect.height()));
-            endPoint = QPointF(rect.right(), floatingPointRect.bottom()-(warningStop*floatingPointRect.height()));
-        }
+            startPoint = QPointF(rect.left(), floatingPointRect.bottom() - (warningStop * floatingPointRect.height()));
+            endPoint = QPointF(rect.right(), floatingPointRect.bottom() - (warningStop * floatingPointRect.height()));
 
-        bufferPainter.drawLine(startPoint, endPoint);
+            bufferPainter.drawLine(startPoint, endPoint);
+        }
 
         bufferPainter.end();
 
@@ -190,9 +185,4 @@ auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::draw(QCPPainter *painter) -> v
     painter->setClipPath(clippingPath);
 
     painter->drawPixmap(topLeft, m_buffers[bufferName]);
-}
-
-auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::setGradientEnabled(bool useGradient) -> void {
-    m_useGradient = useGradient;
-    invalidate();
 }

--- a/src/components/RouteAnalyser/GraphLatencyLayer.cpp
+++ b/src/components/RouteAnalyser/GraphLatencyLayer.cpp
@@ -36,8 +36,8 @@
 
 using namespace std::chrono_literals;
 
-constexpr auto DefaultWarningLatency = 200ms;
-constexpr auto DefaultCriticalLatency = 500ms;
+constexpr auto DefaultWarningLatency = 200.0;
+constexpr auto DefaultCriticalLatency = 500.0;
 
 constexpr auto RoundedRectangleRadius = 10;
 constexpr auto TinyNumber = 0.0001;
@@ -92,9 +92,11 @@ auto Nedrysoft::RouteAnalyser::GraphLatencyLayer::draw(QCPPainter *painter) -> v
     auto rect = parentPlot()->axisRect()->rect();
     auto topLeft = rect.topLeft();
 
-    auto idealStop = m_warningLatency.count()/graphMaxLatency;
-    auto warningStop = m_criticalLatency.count()/graphMaxLatency;
+    auto idealStop = m_warningLatency/(graphMaxLatency*1000.0);
+    auto warningStop = m_criticalLatency/(graphMaxLatency*1000.0);
 
+
+    qDebug() << idealStop << m_warningLatency << graphMaxLatency;
     auto latencySettings = Nedrysoft::RouteAnalyser::LatencySettings::getInstance();
 
     assert(latencySettings!=nullptr);

--- a/src/components/RouteAnalyser/GraphLatencyLayer.h
+++ b/src/components/RouteAnalyser/GraphLatencyLayer.h
@@ -25,7 +25,6 @@
 #define PINGNOO_COMPONENTS_ROUTEANALYSER_GRAPHLATENCYLAYER_H
 
 #include "QCustomPlot/qcustomplot.h"
-#include "chrono"
 
 namespace Nedrysoft { namespace RouteAnalyser {
     /**
@@ -71,8 +70,8 @@ namespace Nedrysoft { namespace RouteAnalyser {
         private:
             //! @cond
 
-            std::chrono::duration<double> m_warningLatency = {};
-            std::chrono::duration<double> m_criticalLatency = {};
+            double m_warningLatency;
+            double m_criticalLatency;
 
             bool m_useGradient;
 

--- a/src/components/RouteAnalyser/GraphLatencyLayer.h
+++ b/src/components/RouteAnalyser/GraphLatencyLayer.h
@@ -43,13 +43,6 @@ namespace Nedrysoft { namespace RouteAnalyser {
             explicit GraphLatencyLayer(QCustomPlot *customPlot);
 
             /**
-             * @brief       Set whether to draw the background as a smooth gradient or steps.
-             *
-             * @param[in]   useGradient true if smooth gradient; otherwise false.
-             */
-            auto setGradientEnabled(bool useGradient) -> void;
-
-            /**
              * @brief       Removes buffered offscreen background Pixmaps.
              */
             static auto removeUnused() -> void;
@@ -69,11 +62,6 @@ namespace Nedrysoft { namespace RouteAnalyser {
 
         private:
             //! @cond
-
-            double m_warningLatency;
-            double m_criticalLatency;
-
-            bool m_useGradient;
 
             static QMap<QString, QPixmap> m_buffers;
             static QMap<QString, uint64_t> m_age;

--- a/src/components/RouteAnalyser/IPingEngine.h
+++ b/src/components/RouteAnalyser/IPingEngine.h
@@ -63,27 +63,27 @@ namespace Nedrysoft { namespace RouteAnalyser {
             /**
              * @brief       Sets the measurement interval for this engine instance.
              *
-             * @param[in]   interval interval time.
+             * @param[in]   interval the time between successive pings in milliseconds.
              *
              * @returns     returns true on success; otherwise false.
              */
-            virtual auto setInterval(std::chrono::milliseconds interval) -> bool = 0;
+            virtual auto setInterval(int interval) -> bool = 0;
 
             /**
              * @brief       Returns the interval set on the engine.
              *
-             * @returns     the interval.
+             * @returns     the interval between pings in milliseconds.
              */
-            virtual auto interval() -> std::chrono::milliseconds = 0;
+            virtual auto interval() -> int = 0;
 
             /**
              * @brief       Sets the reply timeout for this engine instance.
              *
-             * @param[in]   timeout the amount of time before we consider that the packet was lost.
+             * @param[in]   timeout the number of milliseconds to wait for a response.
              *
              * @returns     true on success; otherwise false.
              */
-            virtual auto setTimeout(std::chrono::milliseconds timeout) -> bool = 0;
+            virtual auto setTimeout(int timeout) -> bool = 0;
 
             /**
              * @brief       Starts ping operations for this engine instance.
@@ -130,9 +130,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @returns     the result of the ping.
              */
             virtual auto singleShot(
-                    QHostAddress hostAddress,
-                    int ttl,
-                    double timeout ) -> Nedrysoft::RouteAnalyser::PingResult = 0;
+                QHostAddress hostAddress,
+                int ttl,
+                double timeout
+            ) -> Nedrysoft::RouteAnalyser::PingResult = 0;
 
             /**
              * @brief       Removes a ping target from this engine instance.
@@ -148,7 +149,7 @@ namespace Nedrysoft { namespace RouteAnalyser {
              *
              * @returns     the time epoch
              */
-            virtual auto epoch() -> std::chrono::system_clock::time_point = 0;
+            virtual auto epoch() -> QDateTime = 0;
 
             /**
              * @brief       Signal emitted to indicate the state of a ping request.

--- a/src/components/RouteAnalyser/NewTargetRibbonGroup.cpp
+++ b/src/components/RouteAnalyser/NewTargetRibbonGroup.cpp
@@ -455,7 +455,7 @@ void Nedrysoft::RouteAnalyser::NewTargetRibbonGroup::openTarget(
 
     if (editorManager) {
         auto target = parameters["host"].toString() ;
-        auto intervalTime = parameters["interval"].toDouble();
+        auto intervalTime = parameters["interval"].toDouble()*1000;
         auto ipVersion = parameters["ipversion"].value<Nedrysoft::Core::IPVersion>();
 
         RouteAnalyserEditor *editor = new RouteAnalyserEditor;

--- a/src/components/RouteAnalyser/PingData.cpp
+++ b/src/components/RouteAnalyser/PingData.cpp
@@ -30,7 +30,6 @@
 #include <QHeaderView>
 #include <QStandardItemModel>
 #include <QTableWidget>
-#include <chrono>
 
 Nedrysoft::RouteAnalyser::PingData::PingData(QStandardItemModel *tableModel, int hop, bool hopValid) :
         m_tableModel(tableModel),

--- a/src/components/RouteAnalyser/PingData.cpp
+++ b/src/components/RouteAnalyser/PingData.cpp
@@ -143,12 +143,12 @@ auto Nedrysoft::RouteAnalyser::PingData::updateItem(Nedrysoft::RouteAnalyser::Pi
 
         headerItem->setTextAlignment(Qt::AlignRight);
 
-        headerItem->setText(QString(QObject::tr("%1 ms")).arg((m_currentLatency/1000.0)));
+        headerItem->setText(QString(QObject::tr("%1 ms")).arg((m_currentLatency*1000)));
     }
 
     if (m_minimumLatency < m_tableModel->property("graphMinLatency").toDouble()) {
         if (m_tableModel) {
-            m_tableModel->setProperty("graphMinLatency", QVariant(m_minimumLatency/1000.0));
+            m_tableModel->setProperty("graphMinLatency", QVariant(m_minimumLatency));
         }
     }
 

--- a/src/components/RouteAnalyser/PingData.h
+++ b/src/components/RouteAnalyser/PingData.h
@@ -41,9 +41,6 @@ namespace Nedrysoft { namespace RouteAnalyser {
     class RouteItemTableDelegate;
     class IPlot;
 
-    typedef std::chrono::duration<double, std::ratio<1, 1000>> milliseconds_double;
-    typedef std::chrono::duration<double, std::ratio<1, 1>> seconds_double;
-
     /**
      * @brief       The PingData class is used to store data for a table model.
      *
@@ -109,9 +106,9 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @details     This can optionally be drawn on the latency graph when hovering
              *              over a chart.
              *
-             * @param[in]   latency the latency.
+             * @param[in]   latency the latency in seconds.
              */
-            auto setHistoricalLatency(std::chrono::duration<double> latency) -> void;
+            auto setHistoricalLatency(double latency) -> void;
 
             /**
              * @brief       Updates the route table item with the given result.
@@ -281,11 +278,11 @@ namespace Nedrysoft { namespace RouteAnalyser {
             QString m_hostName;
             QString m_location;
 
-            seconds_double m_currentLatency = {};
-            seconds_double m_maximumLatency = {};
-            seconds_double m_minimumLatency = {};
-            seconds_double m_averageLatency = {};
-            seconds_double m_historicalLatency = {};
+            double m_currentLatency;
+            double m_maximumLatency;
+            double m_minimumLatency;
+            double m_averageLatency;
+            double m_historicalLatency;
 
             QList<Nedrysoft::RouteAnalyser::IPlot *> m_plots;
 

--- a/src/components/RouteAnalyser/PingResult.cpp
+++ b/src/components/RouteAnalyser/PingResult.cpp
@@ -27,7 +27,8 @@ Nedrysoft::RouteAnalyser::PingResult::PingResult() :
     m_sampleNumber(0),
     m_code(PingResult::ResultCode::NoReply),
     m_hostAddress(QHostAddress()),
-    m_target(nullptr) {
+    m_target(nullptr),
+    m_roundTripTime(-1) {
 
 }
 

--- a/src/components/RouteAnalyser/PingResult.cpp
+++ b/src/components/RouteAnalyser/PingResult.cpp
@@ -27,8 +27,6 @@ Nedrysoft::RouteAnalyser::PingResult::PingResult() :
     m_sampleNumber(0),
     m_code(PingResult::ResultCode::NoReply),
     m_hostAddress(QHostAddress()),
-    m_roundTripTime(std::chrono::duration<double>(0)),
-    m_requestTime(std::chrono::system_clock::now()),
     m_target(nullptr) {
 
 }
@@ -39,8 +37,8 @@ Nedrysoft::RouteAnalyser::PingResult::PingResult(
         unsigned long sampleNumber,
         PingResult::ResultCode code,
         const QHostAddress &hostAddress,
-        std::chrono::system_clock::time_point requestTime,
-        std::chrono::duration<double> roundTripTime,
+        QDateTime requestTime,
+        double roundTripTime,
         Nedrysoft::RouteAnalyser::IPingTarget *target) :
 
             m_sampleNumber(sampleNumber),
@@ -56,7 +54,7 @@ auto Nedrysoft::RouteAnalyser::PingResult::sampleNumber() -> unsigned long {
     return m_sampleNumber;
 }
 
-auto Nedrysoft::RouteAnalyser::PingResult::requestTime() -> std::chrono::system_clock::time_point {
+auto Nedrysoft::RouteAnalyser::PingResult::requestTime() -> QDateTime {
     return m_requestTime;
 }
 
@@ -68,7 +66,7 @@ auto Nedrysoft::RouteAnalyser::PingResult::hostAddress() -> QHostAddress {
     return m_hostAddress;
 }
 
-auto Nedrysoft::RouteAnalyser::PingResult::roundTripTime() -> std::chrono::duration<double> {
+auto Nedrysoft::RouteAnalyser::PingResult::roundTripTime() -> double {
     return m_roundTripTime;
 }
 

--- a/src/components/RouteAnalyser/PingResult.h
+++ b/src/components/RouteAnalyser/PingResult.h
@@ -26,9 +26,10 @@
 
 #include "RouteAnalyserSpec.h"
 
+#include <QDateTime>
+#include <QElapsedTimer>
 #include <QHostAddress>
 #include <QObject>
-#include <chrono>
 #include <cmath>
 #include <cstdint>
 
@@ -73,12 +74,14 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   roundTripTime the time taken for the hop to respond.
              * @param[in]   target the target that was pinged.
              */
-            PingResult(unsigned long sampleNumber,
-                       ResultCode code,
-                       const QHostAddress &hostAddress,
-                       std::chrono::system_clock::time_point requestTime,
-                       std::chrono::duration<double> roundTripTime,
-                       Nedrysoft::RouteAnalyser::IPingTarget *target);
+            PingResult(
+                unsigned long sampleNumber,
+                ResultCode code,
+                const QHostAddress &hostAddress,
+                QDateTime requestTime,
+                double roundTripTime,
+                Nedrysoft::RouteAnalyser::IPingTarget *target
+            );
 
         public:
 
@@ -94,7 +97,7 @@ namespace Nedrysoft { namespace RouteAnalyser {
              *
              * @returns     the request time.
              */
-            auto requestTime() -> std::chrono::system_clock::time_point;
+            auto requestTime() -> QDateTime;
 
             /**
              * @brief       The result code for the request (Echo Reply, Timeout).
@@ -119,9 +122,9 @@ namespace Nedrysoft { namespace RouteAnalyser {
              *
              * @details     The round trip time is the elapsed time from the packet being sent to the response.
              *
-             * @returns     the round trip time.
+             * @returns     the round trip time in seconds.
              */
-            auto roundTripTime() -> std::chrono::duration<double>;
+            auto roundTripTime() -> double;
 
             /**
              * @brief       The target associated with this result.
@@ -136,8 +139,8 @@ namespace Nedrysoft { namespace RouteAnalyser {
             unsigned long m_sampleNumber;
             PingResult::ResultCode m_code;
             QHostAddress m_hostAddress;
-            std::chrono::duration<double> m_roundTripTime = {};
-            std::chrono::system_clock::time_point m_requestTime = {};
+            double m_roundTripTime;
+            QDateTime m_requestTime;
             Nedrysoft::RouteAnalyser::IPingTarget *m_target;
 
             //! @endcond

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
@@ -256,20 +256,20 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onPingResult(Nedrysoft::Rout
         case Nedrysoft::RouteAnalyser::PingResult::ResultCode::Ok:
         case Nedrysoft::RouteAnalyser::PingResult::ResultCode::TimeExceeded: {
             QCPRange graphRange = customPlot->yAxis->range();
-            auto requestTime = std::chrono::duration<double>(result.requestTime().time_since_epoch());
+            auto requestTime = static_cast<double>(result.requestTime().toSecsSinceEpoch());
 
-            customPlot->graph(RoundTripGraph)->addData(requestTime.count(), result.roundTripTime().count());
+            customPlot->graph(RoundTripGraph)->addData(requestTime, result.roundTripTime());
 
             if (m_startPoint == -1) {
-                m_startPoint = requestTime.count();
+                m_startPoint = requestTime;
             } else {
-                if (requestTime.count() < m_startPoint) {
-                    m_startPoint = requestTime.count();
+                if (requestTime < m_startPoint) {
+                    m_startPoint = requestTime;
                 }
             }
 
-            if (requestTime.count() > m_endPoint) {
-                m_endPoint = requestTime.count();
+            if (requestTime > m_endPoint) {
+                m_endPoint = requestTime;
             }
 
             updateRanges();
@@ -280,8 +280,8 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onPingResult(Nedrysoft::Rout
 
             switch(m_graphScaleMode) {
                 case ScaleMode::None: {
-                    if (result.roundTripTime().count() > graphRange.upper) {
-                        customPlot->yAxis->setRange(0, result.roundTripTime().count());
+                    if (result.roundTripTime()> graphRange.upper) {
+                        customPlot->yAxis->setRange(0, result.roundTripTime());
                     }
 
                     break;
@@ -311,11 +311,11 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onPingResult(Nedrysoft::Rout
         }
 
         case Nedrysoft::RouteAnalyser::PingResult::ResultCode::NoReply: {
-            auto requestTime = std::chrono::duration<double>(result.requestTime().time_since_epoch());
+            auto requestTime = static_cast<double>(result.requestTime().toSecsSinceEpoch());
 
             QCPBars *barChart = m_barCharts[customPlot];
 
-            barChart->addData(requestTime.count(), 1);
+            barChart->addData(requestTime, 1);
 
             pingData->updateItem(result);
 
@@ -514,11 +514,9 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onRouteResult(
                                     auto tempResultRange = pingData->customPlot()->graph(
                                             RoundTripGraph)->data()->valueRange(foundRange, QCP::sdBoth, valueRange);
 
-                                    auto seconds = std::chrono::duration<double>(tempResultRange.upper);
-
-                                    pingData->setHistoricalLatency(seconds);
+                                    pingData->setHistoricalLatency(tempResultRange.upper);
                                 } else {
-                                    pingData->setHistoricalLatency(std::chrono::duration<double>(-1));
+                                    pingData->setHistoricalLatency(-1);
 
                                     auto topLeft = m_tableModel->index(0, 0);
                                     auto bottomRight = topLeft.sibling(m_tableModel->rowCount() - 1,

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
@@ -48,7 +48,7 @@
 #include <spdlog/spdlog.h>
 
 constexpr auto RoundTripGraph = 0;
-constexpr auto DefaultMaxLatency = 10;
+constexpr auto DefaultMaxLatency = 0.01;
 constexpr auto DefaultTimeWindow = 60.0*10;
 constexpr auto DefaultGraphHeight = 300;
 constexpr auto TableRowHeight = 20;
@@ -186,8 +186,9 @@ Nedrysoft::RouteAnalyser::RouteAnalyserWidget::RouteAnalyserWidget(
                 m_tableView->fontMetrics().boundingRect(pair.second).width() );
 #else
         auto maxWidth = qMax(
-                m_tableView->fontMetrics().horizontalAdvance(pair.first),
-                m_tableView->fontMetrics().horizontalAdvance(pair.second) );
+            m_tableView->fontMetrics().horizontalAdvance(pair.first),
+            m_tableView->fontMetrics().horizontalAdvance(pair.second)
+        );
 #endif
 
         m_tableModel->setHorizontalHeaderItem(static_cast<int>(headerIterator.key()), headerItem);
@@ -258,7 +259,7 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onPingResult(Nedrysoft::Rout
             auto requestTime = static_cast<double>(result.requestTime().toSecsSinceEpoch());
 
             customPlot->graph(RoundTripGraph)->addData(requestTime, result.roundTripTime());
-            
+
             if (m_startPoint == -1) {
                 m_startPoint = requestTime;
             } else {
@@ -448,8 +449,9 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onRouteResult(
 
             customPlot->xAxis->setTicker(dateTicker);
             customPlot->xAxis->setRange(
-                    static_cast<double>(secondsSinceEpoch),
-                    static_cast<double>(secondsSinceEpoch + m_viewportSize) );
+                static_cast<double>(secondsSinceEpoch),
+                static_cast<double>(secondsSinceEpoch + m_viewportSize)
+            );
 
             customPlot->graph(RoundTripGraph)->setLineStyle(QCPGraph::lsStepCenter);
 
@@ -504,7 +506,8 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onRouteResult(
                             for (auto currentItem = 0; currentItem < m_tableModel->rowCount(); currentItem++) {
                                 auto pingData = m_tableModel->item(
                                         currentItem,
-                                        0 )->data().value<Nedrysoft::RouteAnalyser::PingData *>();
+                                        0
+                                )->data().value<Nedrysoft::RouteAnalyser::PingData *>();
 
                                 auto valueRange = QCPRange(x - 1, x + 1);
 

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
@@ -44,7 +44,6 @@
 #include <QHostInfo>
 #include <QTimer>
 #include <cassert>
-#include <chrono>
 #include <spdlog/spdlog.h>
 
 constexpr auto RoundTripGraph = 0;

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
@@ -122,10 +122,8 @@ Nedrysoft::RouteAnalyser::RouteAnalyserWidget::RouteAnalyserWidget(
     m_routeGraphDelegate = new RouteTableItemDelegate;
 
     connect(latencySettings, &Nedrysoft::RouteAnalyser::LatencySettings::gradientChanged, [=](bool useGradient) {
-        m_routeGraphDelegate->setGradientEnabled(useGradient);
+#pragma message("here to change")
     });
-
-    m_routeGraphDelegate->setGradientEnabled(latencySettings->gradientFill());
 
     connect(this, &QObject::destroyed, m_routeGraphDelegate, [this](QObject *) {
         delete m_routeGraphDelegate;
@@ -393,14 +391,11 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onRouteResult(
 
             m_backgroundLayers.append(latencyLayer);
 
-            latencyLayer->setGradientEnabled(latencySettings->gradientFill());
-
             connect(
                 latencySettings,
                 &Nedrysoft::RouteAnalyser::LatencySettings::gradientChanged,
-                [=](bool useGradient) {
-
-                    latencyLayer->setGradientEnabled(useGradient);
+                [=](bool /*useGradient*/) {
+                    latencyLayer->invalidate();
                 }
             );
 
@@ -719,11 +714,11 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::paintEvent(QPaintEvent *pain
 
 auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::setGradientEnabled(bool smoothGradient) -> void {
     for(auto layer : m_backgroundLayers) {
-        layer->setGradientEnabled(smoothGradient);
+        layer->invalidate();
     }
 
     if (m_routeGraphDelegate) {
-        m_routeGraphDelegate->setGradientEnabled(smoothGradient);
+        m_tableView->update();
     }
 }
 

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
@@ -477,89 +477,92 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onRouteResult(
 
             m_graphLines[customPlot] = graphLine;
 
-            connect(customPlot, &QCustomPlot::mouseMove,
-                    [this, customPlot, graphLine, maskedHostName](QMouseEvent *event) {
-                        auto x = customPlot->xAxis->pixelToCoord(event->pos().x());
-                        auto foundRange = false;
-                        auto dataRange = customPlot->graph(RoundTripGraph)->data()->keyRange(foundRange);
+            connect(
+                customPlot,
+                &QCustomPlot::mouseMove,
+                [this, customPlot, graphLine, maskedHostName](QMouseEvent *event) {
+                    auto x = customPlot->xAxis->pixelToCoord(event->pos().x());
+                    auto foundRange = false;
+                    auto dataRange = customPlot->graph(RoundTripGraph)->data()->keyRange(foundRange);
 
-                        graphLine->point1->setCoords(x, 0);
-                        graphLine->point2->setCoords(x, 1);
+                    graphLine->point1->setCoords(x, 0);
+                    graphLine->point2->setCoords(x, 1);
 
-                        customPlot->replot();
+                    customPlot->replot();
 
-                        if (( foundRange ) &&
-                            ( x >= dataRange.lower ) &&
-                            ( x <= dataRange.upper )) {
-                            auto valueString = QString();
-                            /*auto valueResultRange = customPlot->graph(RoundTripGraph)->data()->valueRange(
-                                    foundRange,
-                                    QCP::sdBoth,
-                                    QCPRange(x - 1, x +1) );*/
+                    if (( foundRange ) &&
+                        ( x >= dataRange.lower ) &&
+                        ( x <= dataRange.upper )) {
+                        auto valueString = QString();
+                        /*auto valueResultRange = customPlot->graph(RoundTripGraph)->data()->valueRange(
+                                foundRange,
+                                QCP::sdBoth,
+                                QCPRange(x - 1, x +1) );*/
 
-                            for (auto currentItem = 0; currentItem < m_tableModel->rowCount(); currentItem++) {
-                                auto pingData = m_tableModel->item(
-                                        currentItem,
-                                        0
-                                )->data().value<Nedrysoft::RouteAnalyser::PingData *>();
+                        for (auto currentItem = 0; currentItem < m_tableModel->rowCount(); currentItem++) {
+                            auto pingData = m_tableModel->item(
+                                    currentItem,
+                                    0
+                            )->data().value<Nedrysoft::RouteAnalyser::PingData *>();
 
-                                auto valueRange = QCPRange(x - 1, x + 1);
+                            auto valueRange = QCPRange(x - 1, x + 1);
 
-                                if (pingData->customPlot()) {
-                                    auto tempResultRange = pingData->customPlot()->graph(
-                                            RoundTripGraph)->data()->valueRange(foundRange, QCP::sdBoth, valueRange);
+                            if (pingData->customPlot()) {
+                                auto tempResultRange = pingData->customPlot()->graph(
+                                        RoundTripGraph)->data()->valueRange(foundRange, QCP::sdBoth, valueRange);
 
-                                    pingData->setHistoricalLatency(tempResultRange.upper);
-                                } else {
-                                    pingData->setHistoricalLatency(-1);
-
-                                    auto topLeft = m_tableModel->index(0, 0);
-                                    auto bottomRight = topLeft.sibling(m_tableModel->rowCount() - 1,
-                                                                       m_tableModel->columnCount() - 1);
-
-                                    m_tableModel->dataChanged(topLeft, bottomRight);
-                                }
-                            }
-
-                            this->m_tableModel->setProperty("showHistorical", true);
-
-                            /*
-                            auto seconds = std::chrono::duration<double>(valueResultRange.upper);
-
-                            if (seconds < std::chrono::seconds(1)) {
-                                auto milliseconds =
-                                    std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(seconds);
-
-                                valueString = QString(tr("%1ms")).arg(milliseconds.count(), 0, 'f', 2);
+                                pingData->setHistoricalLatency(tempResultRange.upper);
                             } else {
-                                valueString = QString(tr("%1s")).arg(seconds.count(), 0, 'f', 2);
+                                pingData->setHistoricalLatency(-1);
+
+                                auto topLeft = m_tableModel->index(0, 0);
+                                auto bottomRight = topLeft.sibling(m_tableModel->rowCount() - 1,
+                                                                   m_tableModel->columnCount() - 1);
+
+                                m_tableModel->dataChanged(topLeft, bottomRight);
                             }
-
-                            auto dateTime = QDateTime::fromSecsSinceEpoch(static_cast<qint64>(x));
-
-                            m_pointInfoLabel->setText(FontAwesome::richText(QString("[fas fa-stopwatch] %1").arg(valueString)));
-                            m_hopInfoLabel->setText(FontAwesome::richText(QString("[fas fa-project-diagram] %1 %2").arg(tr("hop")).arg(hop)));
-                            m_hostInfoLabel->setText(FontAwesome::richText(QString("[fas fa-server] %1").arg(maskedHostName)));
-                            m_timeInfoLabel->setText(FontAwesome::richText(QString("[far fa-calendar-alt] %1").arg(dateTime.toString())));
-                            */
-                        } else {
-                            /*
-                            m_pointInfoLabel->setText("");
-                            m_hopInfoLabel->setText("");
-                            m_hostInfoLabel->setText("");
-                            m_timeInfoLabel->setText("");
-                            */
-
-                            this->m_tableModel->setProperty("showHistorical", false);
-
-                            auto topLeft = m_tableModel->index(0, 0);
-                            auto bottomRight = topLeft.sibling(
-                                    m_tableModel->rowCount() - 1,
-                                    m_tableModel->columnCount() - 1 );
-
-                            m_tableModel->dataChanged(topLeft, bottomRight);
                         }
-                    });
+
+                        this->m_tableModel->setProperty("showHistorical", true);
+
+                        /*
+                        auto seconds = std::chrono::duration<double>(valueResultRange.upper);
+
+                        if (seconds < std::chrono::seconds(1)) {
+                            auto milliseconds =
+                                std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(seconds);
+
+                            valueString = QString(tr("%1ms")).arg(milliseconds.count(), 0, 'f', 2);
+                        } else {
+                            valueString = QString(tr("%1s")).arg(seconds.count(), 0, 'f', 2);
+                        }
+
+                        auto dateTime = QDateTime::fromSecsSinceEpoch(static_cast<qint64>(x));
+
+                        m_pointInfoLabel->setText(FontAwesome::richText(QString("[fas fa-stopwatch] %1").arg(valueString)));
+                        m_hopInfoLabel->setText(FontAwesome::richText(QString("[fas fa-project-diagram] %1 %2").arg(tr("hop")).arg(hop)));
+                        m_hostInfoLabel->setText(FontAwesome::richText(QString("[fas fa-server] %1").arg(maskedHostName)));
+                        m_timeInfoLabel->setText(FontAwesome::richText(QString("[far fa-calendar-alt] %1").arg(dateTime.toString())));
+                        */
+                    } else {
+                        /*
+                        m_pointInfoLabel->setText("");
+                        m_hopInfoLabel->setText("");
+                        m_hostInfoLabel->setText("");
+                        m_timeInfoLabel->setText("");
+                        */
+
+                        this->m_tableModel->setProperty("showHistorical", false);
+
+                        auto topLeft = m_tableModel->index(0, 0);
+                        auto bottomRight = topLeft.sibling(
+                                m_tableModel->rowCount() - 1,
+                                m_tableModel->columnCount() - 1 );
+
+                        m_tableModel->dataChanged(topLeft, bottomRight);
+                    }
+                }
+            );
 
             customPlot->installEventFilter(this);
 

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.h
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.h
@@ -86,7 +86,7 @@ namespace Nedrysoft { namespace RouteAnalyser {
              */
             explicit RouteAnalyserWidget(QString targetHost,
                                          Nedrysoft::Core::IPVersion ipVersion,
-                                         double interval,
+                                         int interval,
                                          Nedrysoft::RouteAnalyser::IPingEngineFactory *pingEngineFactory,
                                          QWidget *parent = nullptr );
 
@@ -219,7 +219,7 @@ namespace Nedrysoft { namespace RouteAnalyser {
             QSplitter *m_splitter;
             PlotScrollArea *m_scrollArea;
             Nedrysoft::RouteAnalyser::IPingEngineFactory *m_pingEngineFactory;
-            double m_interval;
+            int m_interval;
             QList<Nedrysoft::RouteAnalyser::GraphLatencyLayer *> m_backgroundLayers;
             Nedrysoft::RouteAnalyser::RouteTableItemDelegate *m_routeGraphDelegate;
             ScaleMode m_graphScaleMode;

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.h
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.h
@@ -84,11 +84,13 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   pingEngineFactory the ping engine factory to use.
              * @param[in]   parent the parent widget.
              */
-            explicit RouteAnalyserWidget(QString targetHost,
-                                         Nedrysoft::Core::IPVersion ipVersion,
-                                         int interval,
-                                         Nedrysoft::RouteAnalyser::IPingEngineFactory *pingEngineFactory,
-                                         QWidget *parent = nullptr );
+            explicit RouteAnalyserWidget(
+                QString targetHost,
+                Nedrysoft::Core::IPVersion ipVersion,
+                int interval,
+                Nedrysoft::RouteAnalyser::IPingEngineFactory *pingEngineFactory,
+                QWidget *parent = nullptr
+            );
 
             /**
              * @brief       Destroys the RouteAnalyserWidget.

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
@@ -137,7 +137,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    std::chrono::duration_cast<milliseconds_double>(pingData->m_minimumLatency).count(), 2, 'f', 2),
+                    pingData->m_minimumLatency*1000.0, 2, 'f', 2),
                     painter,
                     option,
                     index,
@@ -150,7 +150,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    std::chrono::duration_cast<milliseconds_double>(pingData->m_maximumLatency).count(), 2, 'f', 2),
+                    pingData->m_maximumLatency*1000.0, 2, 'f', 2),
                     painter,
                     option,
                     index,
@@ -163,7 +163,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    std::chrono::duration_cast<milliseconds_double>(pingData->m_averageLatency).count(), 2, 'f', 2),
+                    pingData->m_averageLatency*1000.0, 2, 'f', 2),
                     painter,
                     option,
                     index,
@@ -176,7 +176,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    std::chrono::duration_cast<milliseconds_double>(pingData->m_currentLatency).count(), 2, 'f', 2),
+                    pingData->m_currentLatency*1000.0, 2, 'f', 2),
                     painter,
                     option,
                     index,

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
@@ -478,9 +478,9 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintHop(
 
     gradientMap[0] = latencySettings->idealColour();
 
-    gradientMap[latencySettings->warningValue()*interpolationTime] = latencySettings->warningColour();
+    gradientMap[latencySettings->warningValue()] = latencySettings->warningColour();
 
-    gradientMap[latencySettings->criticalValue()*interpolationTime] = latencySettings->criticalColour();
+    gradientMap[latencySettings->criticalValue()] = latencySettings->criticalColour();
 
     gradientMap[1] = latencySettings->criticalColour();
 

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
@@ -429,7 +429,8 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintBubble(
         Nedrysoft::RouteAnalyser::PingData *pingData,
         QPainter *painter,
         const QStyleOptionViewItem &option,
-        const QModelIndex &index, QRgb bubbleColour) const -> void {
+        const QModelIndex &index,
+        QRgb bubbleColour) const -> void {
 
     Q_UNUSED(index)
     Q_UNUSED(pingData)
@@ -477,9 +478,9 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintHop(
 
     gradientMap[0] = latencySettings->idealColour();
 
-    gradientMap[latencySettings->warningValue()/interpolationTime] = latencySettings->warningColour();
+    gradientMap[latencySettings->warningValue()*interpolationTime] = latencySettings->warningColour();
 
-    gradientMap[latencySettings->criticalValue()/interpolationTime] = latencySettings->criticalColour();
+    gradientMap[latencySettings->criticalValue()*interpolationTime] = latencySettings->criticalColour();
 
     gradientMap[1] = latencySettings->criticalColour();
 

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
@@ -36,14 +36,12 @@
 #include <ThemeSupport>
 #include <cassert>
 
-using namespace std::chrono_literals;
-
 constexpr auto AverageLatencyRadius = 4;
 constexpr auto CurrentLatencyLength = 3;
 constexpr auto XOffset = (AverageLatencyRadius*2);
 
-constexpr auto DefaultWarningLatency = 200ms;
-constexpr auto DefaultCriticalLatency = 500ms;
+constexpr auto DefaultWarningLatency = 200.0;
+constexpr auto DefaultCriticalLatency = 500.0;
 
 constexpr auto RoundedRectangleRadius = 10;
 constexpr auto AlternateRowFactor = 12.5;
@@ -475,11 +473,9 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintHop(
 
     gradientMap[0] = latencySettings->idealColour();
 
-    gradientMap[std::chrono::duration<double, std::milli>(m_warningLatency).count() /
-                interpolationTime] = latencySettings->warningColour();
+    gradientMap[m_warningLatency/interpolationTime] = latencySettings->warningColour();
 
-    gradientMap[std::chrono::duration<double, std::milli>(m_criticalLatency).count() /
-                interpolationTime] = latencySettings->criticalColour();
+    gradientMap[m_criticalLatency/interpolationTime] = latencySettings->criticalColour();
 
     gradientMap[1] = latencySettings->criticalColour();
 
@@ -578,8 +574,8 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
 
     painter->setClipPath(clippingPath);
 
-    auto idealStop = m_warningLatency.count() / graphMaxLatency;
-    auto warningStop = m_criticalLatency.count() / graphMaxLatency;
+    auto idealStop = m_warningLatency / graphMaxLatency;
+    auto warningStop = m_criticalLatency / graphMaxLatency;
 
     auto blankRect = option.rect;
 
@@ -607,57 +603,70 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
 
     if (idealStop > 1) {
         graphGradient.setColorAt(
-                0,
-                QColor(latencySettings->idealColour()).darker(colourFactor) );
+            0,
+            QColor(latencySettings->idealColour()).darker(colourFactor)
+        );
 
         graphGradient.setColorAt(
-                1,
-                QColor(latencySettings->idealColour()).darker(colourFactor) );
+            1,
+            QColor(latencySettings->idealColour()).darker(colourFactor)
+        );
     } else {
         if (warningStop > 1) {
             if (idealStop < 1) {
                 graphGradient.setColorAt(
-                        0,
-                        QColor(latencySettings->idealColour()).darker(colourFactor) );
+                    0,
+                    QColor(latencySettings->idealColour()).darker(colourFactor)
+                );
 
                 graphGradient.setColorAt(
-                        1,
-                        QColor(latencySettings->warningColour()).darker(colourFactor) );
+                    1,
+                    QColor(latencySettings->warningColour()).darker(colourFactor)
+                );
 
                 if (!m_useGradient) {
                     graphGradient.setColorAt(
-                            idealStop,
-                            QColor(latencySettings->warningColour()).darker(colourFactor) );
+                        idealStop,
+                        QColor(latencySettings->warningColour()).darker(colourFactor)
+                    );
+
                     graphGradient.setColorAt(
-                            idealStop-TinyNumber,
-                            QColor(latencySettings->idealColour()).darker(colourFactor) );
+                        idealStop-TinyNumber,
+                        QColor(latencySettings->idealColour()).darker(colourFactor)
+                    );
                 }
             }
         } else {
             graphGradient.setColorAt(
-                    0,
-                    QColor(latencySettings->idealColour()).darker(colourFactor) );
+                0,
+                QColor(latencySettings->idealColour()).darker(colourFactor)
+            );
 
             graphGradient.setColorAt(
-                    idealStop,
-                    QColor(latencySettings->warningColour()).darker(colourFactor) );
+                idealStop,
+                QColor(latencySettings->warningColour()).darker(colourFactor)
+            );
 
             graphGradient.setColorAt(
-                    warningStop,
-                    QColor(latencySettings->criticalColour()).darker(colourFactor) );
+                warningStop,
+                QColor(latencySettings->criticalColour()).darker(colourFactor)
+            );
 
             graphGradient.setColorAt(
-                    1,
-                    QColor(latencySettings->criticalColour()).darker(colourFactor) );
+                1,
+                QColor(latencySettings->criticalColour()).darker(colourFactor)
+            );
 
             if (!m_useGradient) {
                 graphGradient.setColorAt(
-                        idealStop-TinyNumber,
-                        QColor(latencySettings->idealColour()).darker(colourFactor) );
+                    idealStop-TinyNumber,
+                    QColor(latencySettings->idealColour()).darker(colourFactor)
+                );
 
                 graphGradient.setColorAt(
-                        warningStop-TinyNumber,
-                        QColor(latencySettings->warningColour()).darker(colourFactor) );
+                    warningStop-TinyNumber,
+                    QColor(latencySettings->warningColour()).darker(colourFactor)
+                );
             }
         }
     }

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
@@ -40,8 +40,8 @@ constexpr auto AverageLatencyRadius = 4;
 constexpr auto CurrentLatencyLength = 3;
 constexpr auto XOffset = (AverageLatencyRadius*2);
 
-constexpr auto DefaultWarningLatency = 200.0;
-constexpr auto DefaultCriticalLatency = 500.0;
+constexpr auto DefaultWarningLatency = 0.1;
+constexpr auto DefaultCriticalLatency = 0.2;
 
 constexpr auto RoundedRectangleRadius = 10;
 constexpr auto AlternateRowFactor = 12.5;
@@ -62,10 +62,7 @@ constexpr auto LatencyLineBorderWidth = 3;
 constexpr auto LatencyLineBorderAlphaLevel = 32;
 
 Nedrysoft::RouteAnalyser::RouteTableItemDelegate::RouteTableItemDelegate(QWidget *parent) :
-        QStyledItemDelegate(parent),
-        m_warningLatency(DefaultWarningLatency),
-        m_criticalLatency(DefaultCriticalLatency),
-        m_useGradient(true) {
+        QStyledItemDelegate(parent) {
 
 }
 
@@ -135,11 +132,12 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    pingData->m_minimumLatency*1000.0, 2, 'f', 2),
-                    painter,
-                    option,
-                    index,
-                    Qt::AlignRight | Qt::AlignVCenter );
+                pingData->m_minimumLatency*1000.0, 2, 'f', 2),
+                painter,
+                option,
+                index,
+                Qt::AlignRight | Qt::AlignVCenter
+            );
 
             break;
         }
@@ -148,11 +146,12 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    pingData->m_maximumLatency*1000.0, 2, 'f', 2),
-                    painter,
-                    option,
-                    index,
-                    Qt::AlignRight | Qt::AlignVCenter );
+                pingData->m_maximumLatency*1000.0, 2, 'f', 2),
+                painter,
+                option,
+                index,
+                Qt::AlignRight | Qt::AlignVCenter
+            );
 
             break;
         }
@@ -161,11 +160,12 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    pingData->m_averageLatency*1000.0, 2, 'f', 2),
-                    painter,
-                    option,
-                    index,
-                    Qt::AlignRight | Qt::AlignVCenter );
+                pingData->m_averageLatency*1000.0, 2, 'f', 2),
+                painter,
+                option,
+                index,
+                Qt::AlignRight | Qt::AlignVCenter
+            );
 
             break;
         }
@@ -174,11 +174,12 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(QString("%1").arg(
-                    pingData->m_currentLatency*1000.0, 2, 'f', 2),
-                    painter,
-                    option,
-                    index,
-                    Qt::AlignRight | Qt::AlignVCenter );
+                pingData->m_currentLatency*1000.0, 2, 'f', 2),
+                painter,
+                option,
+                index,
+                Qt::AlignRight | Qt::AlignVCenter
+            );
 
             break;
         }
@@ -187,11 +188,12 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(
-                    QString("%1").arg(pingData->packetLoss(), 2, 'f', 2),
-                    painter,
-                    option,
-                    index,
-                    Qt::AlignRight | Qt::AlignVCenter );
+                QString("%1").arg(pingData->packetLoss(), 2, 'f', 2),
+                painter,
+                option,
+                index,
+                Qt::AlignRight | Qt::AlignVCenter
+            );
 
             break;
         }
@@ -200,11 +202,12 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
             paintBackground(pingData, painter, option, index);
 
             paintText(
-                    QString("%1").arg(pingData->count()),
-                    painter,
-                    option,
-                    index,
-                    Qt::AlignRight | Qt::AlignVCenter );
+                QString("%1").arg(pingData->count()),
+                painter,
+                option,
+                index,
+                Qt::AlignRight | Qt::AlignVCenter
+            );
 
             break;
         }
@@ -345,8 +348,9 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintInvalidHop(
 
     auto tableView = qobject_cast<const QTableView *>(option.widget);
     auto pen = QPen(
-            QBrush(latencySettings->criticalColour()),
-            option.rect.height() - InvalidHopLineWidth );
+        QBrush(latencySettings->criticalColour()),
+        option.rect.height() - InvalidHopLineWidth
+    );
 
     auto visualIndex = tableView->horizontalHeader()->visualIndex(index.column());
 
@@ -389,8 +393,6 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintInvalidHop(
         }
     }
 
-
-
     if (static_cast<PingData::Fields>(index.column()) == PingData::Fields::Graph)  {
         QPen backgroundPen(option.palette.base(), InvalidHopLineWidth+(invalidHopOutlineWidth*2), Qt::SolidLine, Qt::FlatCap);
 
@@ -413,12 +415,13 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintInvalidHop(
 
     if (static_cast<PingData::Fields>(index.column()) == PingData::Fields::Hop) {
         paintText(
-                QString("%1").arg(pingData->hop()),
-                painter,
-                option,
-                index,
-                Qt::AlignHCenter | Qt::AlignVCenter,
-                OverrideSelectedColour );
+            QString("%1").arg(pingData->hop()),
+            painter,
+            option,
+            index,
+            Qt::AlignHCenter | Qt::AlignVCenter,
+            OverrideSelectedColour
+        );
     }
 }
 
@@ -448,8 +451,9 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintBubble(
     painter->setPen(pen);
 
     painter->drawLine(
-            QPoint(bubbleRect.left(), bubbleRect.center().y()),
-            QPoint(bubbleRect.right(), bubbleRect.center().y()) );
+        QPoint(bubbleRect.left(), bubbleRect.center().y()),
+        QPoint(bubbleRect.right(), bubbleRect.center().y())
+    );
 
     painter->restore();
 }
@@ -473,9 +477,9 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintHop(
 
     gradientMap[0] = latencySettings->idealColour();
 
-    gradientMap[m_warningLatency/interpolationTime] = latencySettings->warningColour();
+    gradientMap[latencySettings->warningValue()/interpolationTime] = latencySettings->warningColour();
 
-    gradientMap[m_criticalLatency/interpolationTime] = latencySettings->criticalColour();
+    gradientMap[latencySettings->criticalValue()/interpolationTime] = latencySettings->criticalColour();
 
     gradientMap[1] = latencySettings->criticalColour();
 
@@ -484,21 +488,25 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintHop(
     paintBackground(pingData, painter, option, index);
 
     if ((option.state & (QStyle::State_Active)) ||
-        (!(option.state & QStyle::State_Active) && !(option.state & QStyle::State_Selected))) {
+        (!(option.state & QStyle::State_Active) &&
+        !(option.state & QStyle::State_Selected))) {
+
         bubbleColour = getInterpolatedColour(
-                gradientMap,
-                pingData->latency(static_cast<int>(PingData::Fields::AverageLatency)) );
+            gradientMap,
+            pingData->latency(static_cast<int>(PingData::Fields::AverageLatency))
+        );
     }
 
     paintBubble(pingData, painter, option, index, bubbleColour.rgb());
 
     paintText(
-            QString("%1").arg(pingData->hop()),
-            painter,
-            option,
-            index,
-            Qt::AlignHCenter | Qt::AlignVCenter,
-            OverrideSelectedColour );
+        QString("%1").arg(pingData->hop()),
+        painter,
+        option,
+        index,
+        Qt::AlignHCenter | Qt::AlignVCenter,
+        OverrideSelectedColour
+    );
 }
 
 auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::getInterpolatedColour(
@@ -541,6 +549,10 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
     auto endPoint = QPointF();
     auto colourFactor = NormalColourFactor;
 
+    auto latencySettings = Nedrysoft::RouteAnalyser::LatencySettings::getInstance();
+
+    assert(latencySettings!=nullptr);
+
     auto graphMaxLatency = pingData->tableModel()->property("graphMaxLatency").toDouble();
 
     if (index.row() & 1) {
@@ -574,8 +586,8 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
 
     painter->setClipPath(clippingPath);
 
-    auto idealStop = m_warningLatency / graphMaxLatency;
-    auto warningStop = m_criticalLatency / graphMaxLatency;
+    auto idealStop = latencySettings->warningValue() / graphMaxLatency;
+    auto warningStop = latencySettings->criticalValue() / graphMaxLatency;
 
     auto blankRect = option.rect;
 
@@ -596,8 +608,6 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
     }
 
     auto rect = thisRect;
-
-    auto latencySettings = Nedrysoft::RouteAnalyser::LatencySettings::getInstance();
 
     QLinearGradient graphGradient = QLinearGradient(QPoint(rect.left(), rect.y()), QPoint(rect.right(), rect.y()));
 
@@ -624,7 +634,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
                     QColor(latencySettings->warningColour()).darker(colourFactor)
                 );
 
-                if (!m_useGradient) {
+                if (!latencySettings->gradientFill()) {
                     graphGradient.setColorAt(
                         idealStop,
                         QColor(latencySettings->warningColour()).darker(colourFactor)
@@ -657,7 +667,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
                 QColor(latencySettings->criticalColour()).darker(colourFactor)
             );
 
-            if (!m_useGradient) {
+            if (!latencySettings->gradientFill()) {
                 graphGradient.setColorAt(
                     idealStop-TinyNumber,
                     QColor(latencySettings->idealColour()).darker(colourFactor)
@@ -685,12 +695,14 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
 
     if (idealStop < 1) {
         startPoint = QPointF(
-                floatingPointRect.left()+(idealStop*floatingPointRect.width()),
-                floatingPointRect.top() );
+            floatingPointRect.left()+(idealStop*floatingPointRect.width()),
+            floatingPointRect.top()
+        );
 
         endPoint = QPointF(
-                floatingPointRect.left()+(idealStop*floatingPointRect.width()),
-                floatingPointRect.bottom() );
+            floatingPointRect.left()+(idealStop*floatingPointRect.width()),
+            floatingPointRect.bottom()
+        );
     }
 
     auto pen = QPen(Qt::DashLine);
@@ -717,12 +729,14 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
 
     if (warningStop < 1) {
         startPoint = QPointF(
-                floatingPointRect.left()+(warningStop*floatingPointRect.width()),
-                floatingPointRect.top() );
+            floatingPointRect.left()+(warningStop*floatingPointRect.width()),
+            floatingPointRect.top()
+        );
 
         endPoint = QPointF(
-                floatingPointRect.left()+(warningStop*floatingPointRect.width()),
-                floatingPointRect.bottom() );
+            floatingPointRect.left()+(warningStop*floatingPointRect.width()),
+            floatingPointRect.bottom()
+        );
     }
 
     painter->drawLine(startPoint, endPoint);
@@ -787,31 +801,34 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintGraph(
 
     if (pingData->tableModel()->property("showHistorical").toBool()) {
         drawLatencyLine(
-                static_cast<int>(PingData::Fields::HistoricalLatency),
-                pingData,
-                painter,
-                option,
-                index,
-                QPen(Qt::darkGray, 2, Qt::DotLine) );
+            static_cast<int>(PingData::Fields::HistoricalLatency),
+            pingData,
+            painter,
+            option,
+            index,
+            QPen(Qt::darkGray, 2, Qt::DotLine)
+        );
     }
 
     // outline the average latency line with a alpha blended black border for clarity
 
     drawLatencyLine(
-            static_cast<int>(PingData::Fields::AverageLatency),
-            pingData,
-            painter,
-            option,
-            index,
-            QPen(QColor::fromRgb(0,0,0,LatencyLineBorderAlphaLevel), LatencyLineBorderWidth, Qt::SolidLine) );
+        static_cast<int>(PingData::Fields::AverageLatency),
+        pingData,
+        painter,
+        option,
+        index,
+        QPen(QColor::fromRgb(0,0,0,LatencyLineBorderAlphaLevel), LatencyLineBorderWidth, Qt::SolidLine)
+    );
 
     drawLatencyLine(
-            static_cast<int>(PingData::Fields::AverageLatency),
-            pingData,
-            painter,
-            option,
-            index,
-            QPen(Qt::red, 1, Qt::SolidLine) );
+        static_cast<int>(PingData::Fields::AverageLatency),
+        pingData,
+        painter,
+        option,
+        index,
+        QPen(Qt::red, 1, Qt::SolidLine)
+    );
 
     painter->restore();
 }
@@ -940,8 +957,4 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::getSiblingData(
     }
 
     return nullptr;
-}
-
-auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::setGradientEnabled(bool useGradient) -> void {
-    m_useGradient = useGradient;
 }

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.h
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.h
@@ -25,7 +25,6 @@
 #define PINGNOO_COMPONENTS_ROUTEANALYSER_ROUTETABLEITEMDELEGATE_H
 
 #include <QStyledItemDelegate>
-#include <chrono>
 #include <cmath>
 
 class QTableView;
@@ -93,10 +92,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @returns     The ping data for the next/previous item. (or invalid)
              */
             auto getSiblingData(
-                    QModelIndex modelIndex,
-                    int adjustment,
-                    const QTableView *tableView,
-                    QRect &rect
+                QModelIndex modelIndex,
+                int adjustment,
+                const QTableView *tableView,
+                QRect &rect
             ) const -> Nedrysoft::RouteAnalyser::PingData *;
 
             /**
@@ -108,10 +107,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   index the model index of the cell.
              */
             auto paintGraph(
-                    Nedrysoft::RouteAnalyser::PingData *pingData,
-                    QPainter *painter,
-                    const QStyleOptionViewItem &option,
-                    const QModelIndex &index
+                Nedrysoft::RouteAnalyser::PingData *pingData,
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index
             ) const -> void;
 
             /**
@@ -123,10 +122,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   index the model index of the cell.
              */
             auto paintBackground(
-                    Nedrysoft::RouteAnalyser::PingData *pingData,
-                    QPainter *painter,
-                    const QStyleOptionViewItem &option,
-                    const QModelIndex &index
+                Nedrysoft::RouteAnalyser::PingData *pingData,
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index
             ) const -> void;
 
             /**
@@ -138,10 +137,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   index the model index of the cell.
              */
             auto paintLocation(
-                    Nedrysoft::RouteAnalyser::PingData *pingData,
-                   QPainter *painter,
-                   const QStyleOptionViewItem &option,
-                   const QModelIndex &index
+                Nedrysoft::RouteAnalyser::PingData *pingData,
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index
             ) const -> void;
 
             /**
@@ -153,10 +152,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   index the model index of the cell.
              */
             auto paintInvalidHop(
-                    Nedrysoft::RouteAnalyser::PingData *pingData,
-                    QPainter *painter,
-                    const QStyleOptionViewItem &option,
-                    const QModelIndex &index
+                Nedrysoft::RouteAnalyser::PingData *pingData,
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index
             ) const -> void;
 
             /**
@@ -169,11 +168,11 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   bubbleColour the colour to draw in.
              */
             auto paintBubble(
-                    Nedrysoft::RouteAnalyser::PingData *pingData,
-                    QPainter *painter,
-                    const QStyleOptionViewItem &option,
-                    const QModelIndex &index,
-                    QRgb bubbleColour
+                Nedrysoft::RouteAnalyser::PingData *pingData,
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index,
+                QRgb bubbleColour
             ) const -> void;
 
             /**
@@ -185,9 +184,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   index the model index of the cell.
              */
             auto paintHop(Nedrysoft::RouteAnalyser::PingData *pingData,
-                          QPainter *painter,
-                          const QStyleOptionViewItem &option,
-                          const QModelIndex &index ) const -> void;
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index
+            ) const -> void;
 
             /**
              * @brief       Returns an interpolated colour.
@@ -212,11 +212,12 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   flags controls how the text is drawn.
              */
             auto paintText(const QString &text,
-                           QPainter *painter,
-                           const QStyleOptionViewItem &option,
-                           const QModelIndex &index,
-                           int alignment = Qt::AlignLeft | Qt::AlignVCenter,
-                           int flags = 0) const -> void;
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index,
+                int alignment = Qt::AlignLeft | Qt::AlignVCenter,
+                int flags = 0
+            ) const -> void;
 
             /**
              * @brief       Draws a latency line on the graph for the given data points in the given colour.
@@ -228,17 +229,19 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   index the model index of the cell.
              * @param[in]   pen  the pen to use to draw the line.
              */
-            auto drawLatencyLine(int field, Nedrysoft::RouteAnalyser::PingData *pingData,
-                                 QPainter *painter,
-                                 const QStyleOptionViewItem &option,
-                                 const QModelIndex &index,
-                                 const QPen &pen) const -> void;
+            auto drawLatencyLine(
+                int field, Nedrysoft::RouteAnalyser::PingData *pingData,
+                QPainter *painter,
+                const QStyleOptionViewItem &option,
+                const QModelIndex &index,
+                const QPen &pen
+            ) const -> void;
 
         private:
             //! @cond
 
-            std::chrono::duration<double> m_warningLatency = {};
-            std::chrono::duration<double> m_criticalLatency = {};
+            double m_warningLatency;
+            double m_criticalLatency;
 
             bool m_useGradient;
 

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.h
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.h
@@ -55,13 +55,6 @@ namespace Nedrysoft { namespace RouteAnalyser {
              */
             auto paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const -> void;
 
-            /**
-             * @brief       Set whether to draw the background as a smooth gradient or steps.
-             *
-             * @param[in]   useGradient true if smooth gradient; otherwise false.
-             */
-            auto setGradientEnabled(bool useGradient) -> void;
-
         private:
 
             /**
@@ -236,16 +229,6 @@ namespace Nedrysoft { namespace RouteAnalyser {
                 const QModelIndex &index,
                 const QPen &pen
             ) const -> void;
-
-        private:
-            //! @cond
-
-            double m_warningLatency;
-            double m_criticalLatency;
-
-            bool m_useGradient;
-
-            //! @endcond
     };
 }}
 

--- a/src/components/RouteEngine/RouteEngine.cpp
+++ b/src/components/RouteEngine/RouteEngine.cpp
@@ -33,8 +33,6 @@
 
 #include <cassert>
 
-using namespace std::chrono_literals;
-
 Nedrysoft::RouteEngine::RouteEngine::RouteEngine() :
         m_routeWorkerThread(nullptr),
         m_routeWorker(nullptr) {
@@ -53,14 +51,16 @@ auto Nedrysoft::RouteEngine::RouteEngine::findRoute(
     m_routeWorker->moveToThread(m_routeWorkerThread);
 
     connect(m_routeWorkerThread,
-            &QThread::started,
-            m_routeWorker,
-            &Nedrysoft::RouteEngine::RouteEngineWorker::doWork );
+        &QThread::started,
+        m_routeWorker,
+        &Nedrysoft::RouteEngine::RouteEngineWorker::doWork
+    );
 
-    connect(m_routeWorkerThread,
-            &QThread::finished,
-            [=]() {
-                m_routeWorkerThread->deleteLater();
+    connect(
+        m_routeWorkerThread,
+        &QThread::finished,
+        [=]() {
+            m_routeWorkerThread->deleteLater();
     });
 
     connect(m_routeWorker,

--- a/src/components/RouteEngine/RouteEngineWorker.cpp
+++ b/src/components/RouteEngine/RouteEngineWorker.cpp
@@ -79,6 +79,8 @@ auto Nedrysoft::RouteEngine::RouteEngineWorker::doWork() -> void {
 
         auto result = pingEngine->singleShot(targetAddresses.at(0), hop, DefaultDiscoveryTimeout);
 
+        qDebug() << hop << ((int)result.code()) << result.roundTripTime();
+
         if (result.code()==Nedrysoft::RouteAnalyser::PingResult::ResultCode::Ok) {
             route.append(result.hostAddress());
             break;

--- a/src/components/RouteEngine/RouteEngineWorker.cpp
+++ b/src/components/RouteEngine/RouteEngineWorker.cpp
@@ -79,8 +79,6 @@ auto Nedrysoft::RouteEngine::RouteEngineWorker::doWork() -> void {
 
         auto result = pingEngine->singleShot(targetAddresses.at(0), hop, DefaultDiscoveryTimeout);
 
-        qDebug() << hop << ((int)result.code()) << result.roundTripTime();
-
         if (result.code()==Nedrysoft::RouteAnalyser::PingResult::ResultCode::Ok) {
             route.append(result.hostAddress());
             break;

--- a/src/libs/ICMPSocket/ICMPSocket.cpp
+++ b/src/libs/ICMPSocket/ICMPSocket.cpp
@@ -233,7 +233,7 @@ auto Nedrysoft::ICMPSocket::ICMPSocket::createWriteSocket(
 auto Nedrysoft::ICMPSocket::ICMPSocket::recvfrom(
         QByteArray &buffer,
         QHostAddress &receiveAddress,
-        std::chrono::milliseconds timeout) -> int {
+        int timeout) -> int {
 
 #if defined(Q_OS_UNIX)
     socklen_t addressLength;
@@ -251,17 +251,18 @@ auto Nedrysoft::ICMPSocket::ICMPSocket::recvfrom(
     descriptorSet.fd = m_socketDescriptor;
     descriptorSet.events = POLLIN;
 
-    auto numberOfReadyDescriptors = poll(&descriptorSet, 1, static_cast<int>(timeout.count()));
+    auto numberOfReadyDescriptors = poll(&descriptorSet, 1, timeout);
 
     if (numberOfReadyDescriptors > 0) {
         if (descriptorSet.events & POLLIN) {
             socketErrorLength = sizeof(socketError);
 
             getsockopt(
-                    m_socketDescriptor,
-                    SOL_SOCKET, SO_ERROR,
-                    reinterpret_cast<char *>(&socketError),
-                    &socketErrorLength );
+                m_socketDescriptor,
+                SOL_SOCKET, SO_ERROR,
+                reinterpret_cast<char *>(&socketError),
+                &socketErrorLength
+            );
 
             memset(&fromAddress, 0, sizeof(fromAddress));
 
@@ -270,12 +271,13 @@ auto Nedrysoft::ICMPSocket::ICMPSocket::recvfrom(
             buffer.resize(ReceiveBufferSize);
 
             auto result = ::recvfrom(
-                                    m_socketDescriptor,
-                                    buffer.data(),
-                                    buffer.length(),
-                                    0,
-                                    reinterpret_cast<sockaddr *>(&fromAddress),
-                                    &addressLength );
+                m_socketDescriptor,
+                buffer.data(),
+                buffer.length(),
+                0,
+                reinterpret_cast<sockaddr *>(&fromAddress),
+                &addressLength
+            );
 
             if (result >= 0) {
                 receiveAddress = QHostAddress(reinterpret_cast<sockaddr *>(&fromAddress));

--- a/src/libs/ICMPSocket/ICMPSocket.h
+++ b/src/libs/ICMPSocket/ICMPSocket.h
@@ -25,7 +25,6 @@
 #define NEDRYSOFT_ICMPSOCKET_ICMPSOCKET_H
 
 #include <QtGlobal>
-#include <chrono>
 
 #if defined(Q_OS_UNIX)
 #include <arpa/inet.h>
@@ -120,19 +119,20 @@ namespace Nedrysoft { namespace ICMPSocket {
              * @returns     the write socket instance.
              */
             static auto createWriteSocket(
-                    int ttl = 0,
-                    Nedrysoft::ICMPSocket::IPVersion version = Nedrysoft::ICMPSocket::V4 ) -> ICMPSocket *;
+                int ttl = 0,
+                Nedrysoft::ICMPSocket::IPVersion version = Nedrysoft::ICMPSocket::V4
+             ) -> ICMPSocket *;
 
             /**
              * @brief       Receives data from a read or write socket.
              *
              * @param[in]   buffer the buffer to receive data.
              * @param[out]  receiveAddress the address that the packet was received from.
-             * @param[in]   timeout read timeout.
+             * @param[in]   timeout read timeout in milliseconds.
              *
              * @returns     -1 on timeout or error; otherwise the number of bytes read.
              */
-            auto recvfrom(QByteArray &buffer, QHostAddress &receiveAddress, std::chrono::milliseconds timeout) -> int;
+            auto recvfrom(QByteArray &buffer, QHostAddress &receiveAddress, int timeout) -> int;
 
             /**
              * @brief       Sends data to a write socket.


### PR DESCRIPTION
- removed std::chrono usage from the application.  The std::chrono library is cumbersome, and although you gain a known unit for a value, it can be incredibly convoluted to work for.  In pingnoo now, if a time duration is shared as an integer, it's milliseconds.  As a double, it's seconds, unless otherwise specified.
- fixed issues with threads mixing std::thread and QThread, this causes problems with thread exiting.  Fixes #77
- fixed: Previous ICMPAPIPingEngine changes made to support singleShot moder equired further work as it was assuming that the engine had been started, with the singleShot changes introduced this is not true, a ping engine can be created and used without requiring a transmission thread (i.e it's a blocking call)