### PR TITLE
feat: text decoration on maximal fields (#81)

### DIFF
--- a/src/components/RouteAnalyser/PingData.cpp
+++ b/src/components/RouteAnalyser/PingData.cpp
@@ -261,3 +261,18 @@ auto Nedrysoft::RouteAnalyser::PingData::count() -> unsigned long  {
 auto Nedrysoft::RouteAnalyser::PingData::setPlots(QList<Nedrysoft::RouteAnalyser::IPlot *> plots) -> void {
     m_plots = plots;
 }
+
+auto Nedrysoft::RouteAnalyser::PingData::setMaximum(
+        Nedrysoft::RouteAnalyser::PingData::Fields field,
+        bool isMaximum ) -> void {
+
+    m_isMaximum[field] = isMaximum;
+}
+
+auto Nedrysoft::RouteAnalyser::PingData::isMaximum(Nedrysoft::RouteAnalyser::PingData::Fields field) -> bool {
+    if (m_isMaximum.contains(field)) {
+        return m_isMaximum[field];
+    }
+
+    return false;
+}

--- a/src/components/RouteAnalyser/PingData.h
+++ b/src/components/RouteAnalyser/PingData.h
@@ -224,6 +224,21 @@ namespace Nedrysoft { namespace RouteAnalyser {
              */
             auto setPlots(QList<Nedrysoft::RouteAnalyser::IPlot *> plots) -> void;
 
+            /**
+             * @brief       Returns whether this item for the given field is the maximum value.
+             *
+             * @returns     true if the field is maximum; otherwise false.
+             */
+            auto isMaximum(Nedrysoft::RouteAnalyser::PingData::Fields field) -> bool;
+
+            /**
+             * @brief       Sets whether this item the given field is the maximum value.
+             *
+             * @param[in]   field the field to set.
+             * @param[in]   isMaximum true if the field is maximum; otherwise false.
+             */
+            auto setMaximum(Nedrysoft::RouteAnalyser::PingData::Fields field, bool isMaximum) -> void;
+
         protected:
             /**
              * @brief       Calculates a running average.
@@ -283,6 +298,8 @@ namespace Nedrysoft { namespace RouteAnalyser {
             double m_minimumLatency;
             double m_averageLatency;
             double m_historicalLatency;
+
+            QMap<Fields, bool> m_isMaximum;
 
             QList<Nedrysoft::RouteAnalyser::IPlot *> m_plots;
 

--- a/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
+++ b/src/components/RouteAnalyser/RouteAnalyserWidget.cpp
@@ -246,6 +246,8 @@ Nedrysoft::RouteAnalyser::RouteAnalyserWidget::~RouteAnalyserWidget() {
 auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onPingResult(Nedrysoft::RouteAnalyser::PingResult result) -> void {
     auto pingData = static_cast<PingData *>(result.target()->userData());
 
+    static QMap<Nedrysoft::RouteAnalyser::PingData::Fields, PingData *> m_maximumMap;
+
     if (!pingData) {
         return;
     }
@@ -306,6 +308,32 @@ auto Nedrysoft::RouteAnalyser::RouteAnalyserWidget::onPingResult(Nedrysoft::Rout
                 case ScaleMode::Fixed: {
                     // TODO: Fixed scaling, user sets the max value.
                     break;
+                }
+            }
+
+            auto fields = QList<PingData::Fields>() <<
+                PingData::Fields::MinimumLatency <<
+                PingData::Fields::MaximumLatency <<
+                PingData::Fields::AverageLatency <<
+                PingData::Fields::CurrentLatency;
+
+
+            for (auto field : fields) {
+                if (m_maximumMap.contains(field)) {
+                    auto currentMax = m_maximumMap[field];
+
+                    if (pingData->latency(static_cast<int>(field)) >
+                        currentMax->latency(static_cast<int>(field)) ) {
+                        currentMax->setMaximum(field, false);
+
+                        m_maximumMap[field] = pingData;
+
+                        pingData->setMaximum(field, true);
+                    }
+                } else {
+                    m_maximumMap[field] = pingData;
+
+                    pingData->setMaximum(field, true);
                 }
             }
 

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.cpp
@@ -121,7 +121,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
         case PingData::Fields::IP: {
             paintBackground(pingData, painter, option, index);
 
-            paintText(pingData->hostAddress(), painter, option, index);
+            paintText(pingData->hostAddress(), painter, option, index, false);
 
             break;
         }
@@ -129,7 +129,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
         case PingData::Fields::HostName: {
             paintBackground(pingData, painter, option, index);
 
-            paintText(pingData->hostName(), painter, option, index);
+            paintText(pingData->hostName(), painter, option, index, false);
 
             break;
         }
@@ -145,6 +145,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
                     painter,
                     option,
                     index,
+                    pingData->isMaximum(PingData::Fields::MinimumLatency),
                     Qt::AlignRight | Qt::AlignVCenter
                 );
             }
@@ -163,6 +164,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
                     painter,
                     option,
                     index,
+                    pingData->isMaximum(PingData::Fields::MaximumLatency),
                     Qt::AlignRight | Qt::AlignVCenter
                 );
             }
@@ -181,6 +183,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
                     painter,
                     option,
                     index,
+                    pingData->isMaximum(PingData::Fields::AverageLatency),
                     Qt::AlignRight | Qt::AlignVCenter
                 );
             }
@@ -199,6 +202,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
                     painter,
                     option,
                     index,
+                    pingData->isMaximum(PingData::Fields::CurrentLatency),
                     Qt::AlignRight | Qt::AlignVCenter
                 );
             }
@@ -217,6 +221,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
                     painter,
                     option,
                     index,
+                    false,
                     Qt::AlignRight | Qt::AlignVCenter
                 );
             }
@@ -235,6 +240,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paint(
                     painter,
                     option,
                     index,
+                    false,
                     Qt::AlignRight | Qt::AlignVCenter
                 );
             }
@@ -262,8 +268,9 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintText(
         const QString &text, QPainter *painter,
         const QStyleOptionViewItem &option,
         const QModelIndex &index,
+        bool bold,
         int alignment,
-        int flags) const -> void {
+        int flags ) const -> void {
 
     Q_UNUSED(index)
 
@@ -273,6 +280,15 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintText(
     auto textRect = option.rect.adjusted(TextMargin, 0, -TextMargin, 0);
 
     painter->save();
+
+    if (bold) {
+        QFont boldFont = painter->font();
+
+        boldFont.setBold(true);
+        boldFont.setUnderline(true);
+
+        painter->setFont(boldFont);
+    }
 
     auto themeSupport = Nedrysoft::ThemeSupport::ThemeSupport::getInstance();
 
@@ -346,7 +362,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintLocation(
     paintBackground(pingData, painter, option, index);
 
     if (!pingData->location().isEmpty()) {
-        paintText(pingData->location(), painter, option, index);
+        paintText(pingData->location(), painter, option, index, false);
     } else {
         auto rc = option.rect;
 
@@ -362,7 +378,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintLocation(
 
         painter->restore();
 
-        paintText(pingData->location(), painter, option, index);
+        paintText(pingData->location(), painter, option, index, false);
     }
 }
 
@@ -449,6 +465,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintInvalidHop(
             painter,
             option,
             index,
+            false,
             Qt::AlignHCenter | Qt::AlignVCenter,
             OverrideSelectedColour
         );
@@ -543,6 +560,7 @@ auto Nedrysoft::RouteAnalyser::RouteTableItemDelegate::paintHop(
         painter,
         option,
         index,
+        false,
         Qt::AlignHCenter | Qt::AlignVCenter,
         OverrideSelectedColour
     );

--- a/src/components/RouteAnalyser/RouteTableItemDelegate.h
+++ b/src/components/RouteAnalyser/RouteTableItemDelegate.h
@@ -24,9 +24,12 @@
 #ifndef PINGNOO_COMPONENTS_ROUTEANALYSER_ROUTETABLEITEMDELEGATE_H
 #define PINGNOO_COMPONENTS_ROUTEANALYSER_ROUTETABLEITEMDELEGATE_H
 
+#include "PingData.h"
+#include <QMap>
 #include <QStyledItemDelegate>
 #include <cmath>
 
+class QStandardItem;
 class QTableView;
 
 namespace Nedrysoft { namespace RouteAnalyser {
@@ -37,6 +40,13 @@ namespace Nedrysoft { namespace RouteAnalyser {
      */
     class RouteTableItemDelegate :
             public QStyledItemDelegate {
+
+        private:
+            class MaximumValue {
+                public:
+                    PingData *m_currentData;
+            };
+
 
         public:
             /**
@@ -203,6 +213,7 @@ namespace Nedrysoft { namespace RouteAnalyser {
              * @param[in]   painter the QPainter to draw to.
              * @param[in]   option the painter options.
              * @param[in]   index the model index of the cell.
+             * @param[in]   bold controls whether the text is drawn in bold.
              * @param[in]   alignment the text alignment flags.
              * @param[in]   flags controls how the text is drawn.
              */
@@ -210,6 +221,7 @@ namespace Nedrysoft { namespace RouteAnalyser {
                 QPainter *painter,
                 const QStyleOptionViewItem &option,
                 const QModelIndex &index,
+                bool bold = false,
                 int alignment = Qt::AlignLeft | Qt::AlignVCenter,
                 int flags = 0
             ) const -> void;
@@ -231,6 +243,10 @@ namespace Nedrysoft { namespace RouteAnalyser {
                 const QModelIndex &index,
                 const QPen &pen
             ) const -> void;
+
+        private:
+            QMap<Nedrysoft::RouteAnalyser::PingData::Fields, QPersistentModelIndex *> m_maximumMap;
+
     };
 }}
 


### PR DESCRIPTION
- in the table, the latency fields will now draw the maximum of each type in a bold+underlined font, allows a quick glance at the table to see this information without having to manually look for it.