### PR TITLE
fix: crash when tab is closed

### DIFF
--- a/src/components/Core/EditorManager.cpp
+++ b/src/components/Core/EditorManager.cpp
@@ -183,7 +183,7 @@ Nedrysoft::Core::EditorManager::EditorManager(EditorManagerTabWidget *tabWidget)
 
         auto contextManager = Nedrysoft::Core::IContextManager::getInstance();
 
-        if (contextManager) {
+        if (contextManager && newEditor) {
             contextManager->setContext(newEditor->contextId());
         }
 


### PR DESCRIPTION
newEditor value is nullptr and it is being dereferenced

This solves https://github.com/nedrysoft/pingnoo/issues/100